### PR TITLE
Added superbuild-icubhead-withuser image

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -22,4 +22,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: icub-tech-iit/docker-deployment-images
           event-type: cron_trigger
-          client-payload: '{"version": "master", "type": "cron_trigger", "img_list": "superbuild superbuild-tensorflow-cpu superbuild-tensorflow-gpu superbuild-pytorch superbuild-icubhead superbuild-nvidia superbuild-nvidia-10.1 superbuild-gazebo blender gazebo"}'
+          client-payload: '{"version": "master", "type": "cron_trigger", "img_list": "superbuild superbuild-tensorflow-cpu superbuild-tensorflow-gpu superbuild-pytorch superbuild-icubhead superbuild-icubhead-withuser superbuild-nvidia superbuild-nvidia-10.1 superbuild-gazebo blender gazebo"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,4 +76,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: icub-tech-iit/docker-deployment-images
           event-type: repository_trigger
-          client-payload: '{"version": "${{ steps.get_version.outputs.version }}", "type": "repository_trigger", "img_list": "superbuild superbuild-tensorflow-cpu superbuild-tensorflow-gpu superbuild-pytorch superbuild-icubhead superbuild-nvidia superbuild-nvidia-10.1 superbuild-gazebo blender gazebo"}'
+          client-payload: '{"version": "${{ steps.get_version.outputs.version }}", "type": "repository_trigger", "img_list": "superbuild superbuild-tensorflow-cpu superbuild-tensorflow-gpu superbuild-pytorch superbuild-icubhead superbuild-icubhead-withuser superbuild-nvidia superbuild-nvidia-10.1 superbuild-gazebo blender gazebo"}'

--- a/dockerfile_images/basic/superbuild-icubhead-withuser/Dockerfile
+++ b/dockerfile_images/basic/superbuild-icubhead-withuser/Dockerfile
@@ -1,0 +1,126 @@
+#start from image passed by argument during build process. Usually it is an ubuntu image plus mesa library.
+ARG START_IMG="none"
+
+FROM $START_IMG
+
+LABEL maintainer="valentina.gaggero@iit.it, jacopo.losi@iit.it"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG USERNAME=icub
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+
+RUN apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+ 
+
+USER $USERNAME
+
+RUN sudo mkdir /etc/bash_completion.d/ &&\
+    sudo apt-get install -y \
+        # MISC
+        bash-completion \
+        git \
+        vim \
+        apt-utils
+
+
+#Some definitions
+ARG CMAKE_GENERATOR="Unix Makefiles"
+ARG BUILD_TYPE=Release
+ARG CMAKE_EXTRA_OPTIONS=-j2
+ARG INSTALL_DIR=/home/icub/install_dir
+ARG release="master"
+ARG sbtag="Stable"
+ARG METADATA_FILE=/home/icub/install_dir/bin/setup_metadata.sh
+
+
+# Setup entrypoint
+ARG ROBOTOLOGY_INITIALIZATION_FILE=/usr/local/bin/setup_robotology_tdd.sh
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY setup.sh ${ROBOTOLOGY_INITIALIZATION_FILE}
+RUN sudo chown -R icub: /usr/local/bin/entrypoint.sh
+RUN sudo chown -R icub: /usr/local/bin/setup_robotology_tdd.sh
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
+
+
+ARG PROJECTS_DIR=/home/icub/projects
+
+#ENV DEBIAN_FRONTEND=noninteractive is not sufficient
+RUN echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections &&\
+    mkdir ${PROJECTS_DIR} && cd ${PROJECTS_DIR} &&\
+    git clone https://github.com/robotology/robotology-superbuild.git &&\
+    cd robotology-superbuild &&\
+    git checkout ${release} -b ${release}_branch &&\
+    sudo ./scripts/install_apt_dependencies.sh &&\
+    mkdir build && cd build &&\
+      cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DNON_INTERACTIVE_BUILD:BOOL=ON \
+        -DROBOTOLOGY_ENABLE_CORE:BOOL=ON \
+        -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=ON \
+        -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=ON \
+        -DYCM_USE_DEPRECATED:BOOL=OFF \
+        -DROBOTOLOGY_USES_GAZEBO=OFF \
+        -DROBOTOLOGY_PROJECT_TAGS=${sbtag} \
+        -DYCM_EP_INSTALL_DIR=${INSTALL_DIR} \
+        -DENABLE_yarpmod_grabber:BOOL=ON \
+       &&\
+    #Build all the projects &&\
+    cmake --build . --target update-all -- -j4 &&\
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS}
+
+
+ RUN echo "source ${INSTALL_DIR}/share/robotology-superbuild/setup.sh" >>  $ROBOTOLOGY_INITIALIZATION_FILE
+ RUN echo "source ${METADATA_FILE}" >> $ROBOTOLOGY_INITIALIZATION_FILE
+
+# # The bashrc is read only when opening an interactive shell. Let other projects find packages contained
+# # in the superbuild.
+ ENV CMAKE_PREFIX_PATH=${INSTALL_DIR}
+
+#add checkRobotInterface
+RUN cd ${PROJECTS_DIR} &&\
+    git clone https://github.com/icub-tech-iit/appsAway.git && \
+    cd  appsAway/modules/checkRobotInterface && \
+    mkdir build && cd build && \
+    cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        &&\
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS} && \
+    cp ./checkRobotInterface /home/icub/install_dir/bin
+
+
+
+#The EXPOSE instruction does not actually publish the port.
+#It functions as a type of documentation between the person who builds the image and the person who runs the container, about which ports are intended to be published.
+#To actually publish the port when running the container, use the -p flag on docker run to publish and map one or more ports, or the -P flag to publish all exposed ports and map them to high-order ports.
+EXPOSE 10000/tcp 10000/udp
+
+# Some QT-Apps don't show controls without this
+ENV QT_X11_NO_MITSHM 1
+ENV YARP_COLORED_OUTPUT 1
+
+
+
+ARG metadata="none"
+
+ENV img_metadata=${metadata}
+RUN echo "File metadata = ${METADATA_FILE}"
+RUN echo 'export img_metadata=${metadata}'  >> $METADATA_FILE
+RUN echo 'echo 'This images has release=$release and had been building with superbuild_tag=$sbtag. Metadata=$metadata ' '  >> $METADATA_FILE
+
+
+CMD ["bash"]
+

--- a/dockerfile_images/basic/superbuild-icubhead-withuser/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-icubhead-withuser/conf_build.ini
@@ -1,0 +1,10 @@
+[sources]
+START_IMG=ubuntu:focal
+$(cat DATE_TAG)
+release={{steps.get_version.outputs.VERSION}}
+sbtag={{matrix.tag}}
+
+[tag]
+icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+
+[superbuild]

--- a/dockerfile_images/basic/superbuild-icubhead-withuser/entrypoint.sh
+++ b/dockerfile_images/basic/superbuild-icubhead-withuser/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+if [ -z "$(which setup_robotology_tdd.sh)" ] ; then
+    echo "File setup_robotology_tdd.sh not found."
+    exit 1
+fi
+
+source setup_robotology_tdd.sh
+
+echo "[ -r /usr/share/bash-completion/bash_completion   ] && . /usr/share/bash-completion/bash_completion" >> /home/icub/.bashrc
+echo "[ -r /usr/local/bin/setup_robotology_tdd.sh   ] && . /usr/local/bin/setup_robotology_tdd.sh" >> /home/icub/.bashrc
+
+# If a CMD is passed, execute it
+exec "$@"
+


### PR DESCRIPTION
In this PR I added all the needed files to compile a new image based on `superbuild-icubhead` but provided the user `icub` instead of relays on `root`. 

This should help in developing and testing tasks.

Since this image has been done to help the developer, the `docker4production `file has been removed.

Anyway, if we'll ascertain that such an image is useful for the deployment also, then the `docker4production` file could be added.




I already tested the image on my personal laptop