### PR TITLE
Improve workflow file for adding docker images to both docker-hub GHCR

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -20,6 +20,6 @@ jobs:
           GITHUB_APPS_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          repository: valegagge/docker-deployment-images-testing
+          repository: {{ github.repository }}
           event-type: cron_trigger
           client-payload: '{"version": "master", "type": "cron_trigger", "img_list": "superbuild superbuild-tensorflow-cpu superbuild-tensorflow-gpu superbuild-pytorch superbuild-icubhead superbuild-icubhead-withuser superbuild-nvidia superbuild-nvidia-10.1 superbuild-gazebo blender gazebo"}'

--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -20,6 +20,6 @@ jobs:
           GITHUB_APPS_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          repository: MSECode/docker-deployment-images-testing
+          repository: valegagge/docker-deployment-images-testing
           event-type: cron_trigger
           client-payload: '{"version": "master", "type": "cron_trigger", "img_list": "superbuild superbuild-tensorflow-cpu superbuild-tensorflow-gpu superbuild-pytorch superbuild-icubhead superbuild-icubhead-withuser superbuild-nvidia superbuild-nvidia-10.1 superbuild-gazebo blender gazebo"}'

--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -20,6 +20,6 @@ jobs:
           GITHUB_APPS_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          repository: {{ github.repository }}
+          repository: ${{ github.repository }}
           event-type: cron_trigger
           client-payload: '{"version": "master", "type": "cron_trigger", "img_list": "superbuild superbuild-tensorflow-cpu superbuild-tensorflow-gpu superbuild-pytorch superbuild-icubhead superbuild-icubhead-withuser superbuild-nvidia superbuild-nvidia-10.1 superbuild-gazebo blender gazebo"}'

--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -20,6 +20,6 @@ jobs:
           GITHUB_APPS_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          repository: icub-tech-iit/docker-deployment-images
+          repository: MSECode/docker-deployment-images-testing
           event-type: cron_trigger
           client-payload: '{"version": "master", "type": "cron_trigger", "img_list": "superbuild superbuild-tensorflow-cpu superbuild-tensorflow-gpu superbuild-pytorch superbuild-icubhead superbuild-icubhead-withuser superbuild-nvidia superbuild-nvidia-10.1 superbuild-gazebo blender gazebo"}'

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -14,6 +14,7 @@ env:
   REPOSITORY_OWNER: ${{ github.repository_owner }}
   DOCKERHUB_OWNER: ${{ secrets.DOCKERHUB_USERNAME }}
   DEFAULT_USER: defaultuser
+  IMAGE_PREFIX: sw_deployments_
 
 jobs:
     debug:
@@ -443,7 +444,7 @@ jobs:
                   tag_flag=false
                   demos_flag=true
               fi
-              if [ "$line" != "[sources]" ] && [ "$line" != "[binaries]" ] && [ "$line" != "[tag]" ] && [ "$line" != "[tag-github]" ] && [ "$line" != "[superbuild]" ] && [ "$line" != "[children]" ] && [ "$line" != "[demos]" ] &&  [  "$line" != ""  ]
+              if [ "$line" != "[sources]" ] && [ "$line" != "[binaries]" ] && [ "$line" != "[tag]" ] && [ "$line" != "[superbuild]" ] && [ "$line" != "[children]" ] && [ "$line" != "[demos]" ] &&  [  "$line" != ""  ]
               then
                 if [[ $sources_flag != false ]]
                 then
@@ -568,7 +569,7 @@ jobs:
         - uses: oprypin/find-latest-tag@v1
           if: matrix.version == 'release'
           with:
-            repository: valegagge/docker-deployment-images-testing
+            repository: ${{ env.REPOSITORY_NAME }}
             releases-only: true  
           id: release-version
 
@@ -637,6 +638,8 @@ jobs:
               line=$(echo "$line" > temp.tmp && sed -i 's/{{matrix.apps}}/${{matrix.apps}}/g' temp.tmp && cat temp.tmp)
               line=$(echo "$line" > temp.tmp && sed -i 's/{{matrix.version}}/${{matrix.version}}/g' temp.tmp && cat temp.tmp)
               line=$(echo "$line" > temp.tmp && sed -i 's/{{steps.get_version.outputs.VERSION}}/${{steps.get_version.outputs.VERSION}}/g' temp.tmp && cat temp.tmp)
+              line=$(echo "$line" > temp.tmp && sed -i 's/{{env.DEFAULT_USER}}/${{env.DEFAULT_USER}}/g' temp.tmp && cat temp.tmp)
+
               if [ "$line" == "[sources]" ]
               then
                   sources_flag=true
@@ -658,13 +661,6 @@ jobs:
                   sources_flag=false
                   binaries_flag=false
                   tag_flag=true
-                  demos_flag=false
-              fi
-              if [ "$line" == "[tag-github]" ]
-              then
-                  sources_flag=false
-                  binaries_flag=false
-                  tag_flag=false
                   demos_flag=false
               fi
               if [ "$line" == "[children]" ]
@@ -692,7 +688,7 @@ jobs:
                   tag_flag=false
                   demos_flag=true
               fi
-              if [ "$line" != "[sources]" ] && [ "$line" != "[binaries]" ] && [ "$line" != "[tag]" ] && [ "$line" != "[tag-github]" ] && [ "$line" != "[superbuild]" ] && [ "$line" != "[children]" ] && [ "$line" != "[demos]" ] &&  [  "$line" != ""  ]
+              if [ "$line" != "[sources]" ] && [ "$line" != "[binaries]" ] && [ "$line" != "[tag]" ] && [ "$line" != "[superbuild]" ] && [ "$line" != "[children]" ] && [ "$line" != "[demos]" ] &&  [  "$line" != ""  ]
               then
                 if [[ $sources_flag != false ]]
                 then
@@ -704,7 +700,7 @@ jobs:
                 fi  
                 if [[ $tag_flag != false ]] 
                 then
-                    tag_arg="--tag ${{ env.REPOSITORY_OWNER }}/\"$line\""
+                    tag_arg="--tag ${{env.DEFAULT_USER}}/\"$line\""
                     img_name="\"$line"
                 fi
               fi
@@ -730,39 +726,51 @@ jobs:
           if: steps.get_args.outputs.CMPL_SRC == 'true'
           run: docker build ${{ steps.get_args.outputs.SRC_ARGS }} --no-cache ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}} --file ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}}/Dockerfile ${{ steps.get_args.outputs.TAG_ARGS }}_sources" 
 
+        - name: Tag source images for dockerhub
+          id: tag-sources-dockerhub
+          if: steps.get_args.outputs.CMPL_SRC == 'true'
+          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources"
+
         - name: Push Docker source images
           id: push-sources
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker push ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME }}_sources" 
+          run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources" 
+
+        - name: Tag source images for Ghcr.io
+          id: tag-sources-ghcr
+          if: steps.get_args.outputs.CMPL_SRC == 'true'
+          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources"
+
+        - name: Push source images to Ghcr.io
+          id: push-sources-ghcr
+          if: steps.get_args.outputs.CMPL_SRC == 'true'
+          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources" 
 
         - name: Build Docker binaries images
           id: build-binaries
           if: steps.get_args.outputs.CMPL_BIN == 'true'
           run: docker build  ${{ steps.get_args.outputs.BIN_ARGS }} --no-cache ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}} --file ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}}/Dockerfile4Production ${{ steps.get_args.outputs.TAG_ARGS }}_binaries"
 
+        - name: Tag binaries images for dockerhub
+          id: tag-binaries-dockerhub
+          if: steps.get_args.outputs.CMPL_BIN == 'true'
+          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_binaries" ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
+
         - name: Push Docker binaries images
           id: push-binaries
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker push ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
- 
-        # - name: Trigger testing pipeline for source image
-        #   if: steps.build-sources.outcome == 'success' && steps.push-sources.outcome == 'success' && steps.get_args.outputs.demos_flag_output == 'true' && ! cancelled()
-        #   uses: peter-evans/repository-dispatch@v1
-        #   with:
-        #     token: ${{ secrets.GITHUB_TOKEN  }}
-        #     repository: valegagge/docker-deployment-images-testing
-        #     event-type: app_testing_from_code
-        #     client-payload: '{"type": "app_testing_from_code", "app_list": "${{ steps.get_args.outputs.demos_matrix }}", "img_list": "icubteamcode/${{matrix.apps}}", "version_list": "master", "tag_list": "sources", "children_flag": ${{needs.check_files.outputs.children_flag}} }'
+          run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
 
-        # - name: Trigger testing pipeline for binary image
-        #   if: steps.build-binaries.outcome == 'success' && steps.push-binaries.outcome == 'success' && steps.get_args.outputs.demos_flag_output == 'true' && ! cancelled()
-        #   uses: peter-evans/repository-dispatch@v1
-        #   with:
-        #     token: ${{ secrets.GITHUB_TOKEN  }}
-        #     repository: valegagge/docker-deployment-images-testing
-        #     event-type: app_testing_from_code
-        #     client-payload: '{"type": "app_testing_from_code", "app_list": "${{ steps.get_args.outputs.demos_matrix }}", "img_list": "icubteamcode/${{matrix.apps}}", "version_list": "master", "tag_list": "binaries", "children_flag": ${{needs.check_files.outputs.children_flag}} }'
+        - name: Tag binaries images for ghcr
+          id: tag-binaries-ghcr
+          if: steps.get_args.outputs.CMPL_BIN == 'true'
+          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_binaries" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
         
+        - name: Push binaries images to ghcr
+          id: push-binaries-ghcr
+          if: steps.get_args.outputs.CMPL_BIN == 'true'
+          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
+
     trigger_children_build:
       runs-on: [ubuntu-latest]
       needs: [build_and_push_custom, build_and_push_superbuild, check_files]
@@ -788,30 +796,3 @@ jobs:
             repository: ${{ env.REPOSITORY_NAME }}
             event-type: cron_trigger
             client-payload: '{"type": "cron_trigger", "img_list": "${{ needs.check_files.outputs.children_matrix }}"}'
-
-
-    # trigger_test_build_sources:
-    #   runs-on: [self-hosted, code]
-    #   needs: [build_and_push_superbuild, check_files]
-    #   if: needs.check_files.outputs.demos_flag == 'true' && ! cancelled()
-    #   steps:
-    #     - name: Repository Dispatch
-    #       uses: peter-evans/repository-dispatch@v1
-    #       with:
-    #         token: ${{ secrets.GITHUB_TOKEN  }}
-    #         repository: icub-tech-iit/code
-    #         event-type: app_testing_from_code
-    #         client-payload: '{"type": "app_testing_from_code", "app_list": "${{ needs.check_files.outputs.demos_matrix }}", "img_list": "${{ needs.build_and_push_superbuild.outputs.img_name }}", "version_list": "${{needs.build_and_push_superbuild.outputs.version_name}}-${{needs.build_and_push_superbuild.outputs.tag_name}}_master", "tag_list": "sources"}'
-
-    # trigger_test_build_binaries:
-    #   runs-on: [self-hosted, code]
-    #   needs: [build_and_push_superbuild, check_files]
-    #   if: needs.check_files.outputs.demos_flag == 'true' && ! cancelled()
-    #   steps:
-    #     - name: Repository Dispatch
-    #       uses: peter-evans/repository-dispatch@v1
-    #       with:
-    #         token: ${{ secrets.GITHUB_TOKEN  }}
-    #         repository: icub-tech-iit/code
-    #         event-type: app_testing_from_code
-    #         client-payload: '{"type": "app_testing_from_code", "app_list": "${{ needs.check_files.outputs.demos_matrix }}", "img_list": "${{ needs.build_and_push_superbuild.outputs.img_name }}", "version_list": "${{needs.build_and_push_superbuild.outputs.version_name}}-${{needs.build_and_push_superbuild.outputs.tag_name}}_master", "tag_list": "binaries"}'

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
     debug:
@@ -504,12 +505,12 @@ jobs:
         - name: tag source images for Ghcr.io
           id: tag-sources
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker tag ${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ env.REGISTRY }}/${{ github.repository }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
+          run: docker tag ${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
 
         - name: Push Docker source images to Ghcr.io
           id: push-sources-ghcr
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker push ${{ env.REGISTRY }}/${{ github.repository }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
+          run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
 
         - name: Build Docker binaries images
           id: build-binaries
@@ -780,7 +781,7 @@ jobs:
           uses: peter-evans/repository-dispatch@v1
           with:
             token: ${{ secrets.GITHUB_TOKEN  }}
-            repository: valegagge/docker-deployment-images-testing
+            repository: ${{ env.IMAGE_NAME }}
             event-type: repository_trigger
             client-payload: '{"version": "${{ github.event.client_payload.version }}", "type": "repository_trigger", "img_list": "${{ needs.check_files.outputs.children_matrix }}"}'
             
@@ -790,7 +791,7 @@ jobs:
           uses: peter-evans/repository-dispatch@v1
           with:
             token: ${{ secrets.GITHUB_TOKEN  }}
-            repository: valegagge/docker-deployment-images-testing
+            repository: ${{ env.IMAGE_NAME }}
             event-type: cron_trigger
             client-payload: '{"type": "cron_trigger", "img_list": "${{ needs.check_files.outputs.children_matrix }}"}'
 

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -590,6 +590,14 @@ jobs:
         - name: Login to DockerHub Registry
           run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
+  #########################################################################################        
+        - name: Log in to the Container registry
+          uses: docker/login-action@v2.0.0
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }} 
+
   ##################### Command to set the tag for the date argument ######################
         - name: set date argument for Docker build
           run: |

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -9,6 +9,10 @@ on:
     repository_dispatch:
         types: [repository_trigger,robotology_trigger, cron_trigger]
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
     debug:
       runs-on: [ubuntu-latest]
@@ -297,7 +301,7 @@ jobs:
         - uses: oprypin/find-latest-tag@v1
           if: matrix.version == 'release'
           with:
-            repository: MSECode/docker-deployment-images-testing
+            repository: ${{ env.IMAGE_NAME }}
             releases-only: true  
           id: release-version
 
@@ -501,12 +505,12 @@ jobs:
         - name: tag source images for Ghcr.io
           id: tag-sources
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker tag ${{ steps.get_args.outputs.IMG_NAME }}_sources" ghcr.io/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
+          run: docker tag ${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ env.REGISTRY }}/${{env.IMAGE_NAME}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
 
         - name: Push Docker source images to Ghcr.io
           id: push-sources-ghcr
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker push ghcr.io/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
+          run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
 
         - name: Build Docker binaries images
           id: build-binaries
@@ -523,7 +527,7 @@ jobs:
         #   uses: peter-evans/repository-dispatch@v1
         #   with:
         #     token: ${{ secrets.GITHUB_TOKEN  }}
-        #     repository: MSECode/docker-deployment-images-testing
+        #     repository: {{ }}
         #     event-type: app_testing_from_code
         #     client-payload: '{"type": "app_testing_from_code", "app_list": "${{ steps.get_args.outputs.demos_matrix }}", "img_list": "icubteamcode/${{matrix.apps}}", "version_list": ${{steps.get_version.outputs.VERSION}}-${{steps.get_version.outputs.TAG}}, "tag_list": "sources", "children_flag": ${{needs.check_files.outputs.children_flag}}}'
 
@@ -532,7 +536,7 @@ jobs:
         #   uses: peter-evans/repository-dispatch@v1
         #   with:
         #     token: ${{ secrets.GITHUB_TOKEN  }}
-        #     repository: MSECode/docker-deployment-images-testing
+        #     repository: {{ }}
         #     event-type: app_testing_from_code
         #     client-payload: '{"type": "app_testing_from_code", "app_list": "${{ steps.get_args.outputs.demos_matrix }}","img_list": "icubteamcode/${{matrix.apps}}", "version_list": ${{steps.get_version.outputs.VERSION}}-${{steps.get_version.outputs.TAG}}, "tag_list": "binaries", "children_flag": ${{needs.check_files.outputs.children_flag}}}'
           
@@ -559,7 +563,7 @@ jobs:
         - uses: oprypin/find-latest-tag@v1
           if: matrix.version == 'release'
           with:
-            repository: MSECode/docker-deployment-images-testing
+            repository: {{ env.IMAGE_NAME }}
             releases-only: true  
           id: release-version
 
@@ -752,7 +756,7 @@ jobs:
         #   uses: peter-evans/repository-dispatch@v1
         #   with:
         #     token: ${{ secrets.GITHUB_TOKEN  }}
-        #     repository: MSECode/docker-deployment-images-testing
+        #     repository: {{ env.IMAGE_NAME }}
         #     event-type: app_testing_from_code
         #     client-payload: '{"type": "app_testing_from_code", "app_list": "${{ steps.get_args.outputs.demos_matrix }}", "img_list": "icubteamcode/${{matrix.apps}}", "version_list": "master", "tag_list": "sources", "children_flag": ${{needs.check_files.outputs.children_flag}} }'
 
@@ -761,7 +765,7 @@ jobs:
         #   uses: peter-evans/repository-dispatch@v1
         #   with:
         #     token: ${{ secrets.GITHUB_TOKEN  }}
-        #     repository: MSECode/docker-deployment-images-testing
+        #     repository: {{ env.IMAGE_NAME }}
         #     event-type: app_testing_from_code
         #     client-payload: '{"type": "app_testing_from_code", "app_list": "${{ steps.get_args.outputs.demos_matrix }}", "img_list": "icubteamcode/${{matrix.apps}}", "version_list": "master", "tag_list": "binaries", "children_flag": ${{needs.check_files.outputs.children_flag}} }'
         
@@ -777,7 +781,7 @@ jobs:
           uses: peter-evans/repository-dispatch@v1
           with:
             token: ${{ secrets.GITHUB_TOKEN  }}
-            repository: MSECode/docker-deployment-images-testing
+            repository: {{ env.IMAGE_NAME }}
             event-type: repository_trigger
             client-payload: '{"version": "${{ github.event.client_payload.version }}", "type": "repository_trigger", "img_list": "${{ needs.check_files.outputs.children_matrix }}"}'
             
@@ -787,7 +791,7 @@ jobs:
           uses: peter-evans/repository-dispatch@v1
           with:
             token: ${{ secrets.GITHUB_TOKEN  }}
-            repository: MSECode/docker-deployment-images-testing
+            repository: {{ env.IMAGE_NAME }}
             event-type: cron_trigger
             client-payload: '{"type": "cron_trigger", "img_list": "${{ needs.check_files.outputs.children_matrix }}"}'
 

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -394,6 +394,7 @@ jobs:
               line=$(echo "$line" > temp.tmp && sed -i 's/{{matrix.version}}/${{matrix.version}}/g' temp.tmp && cat temp.tmp)
               line=$(echo "$line" > temp.tmp && sed -i 's/{{matrix.apps}}/${{matrix.apps}}/g' temp.tmp && cat temp.tmp)
               line=$(echo "$line" > temp.tmp && sed -i 's/{{steps.get_version.outputs.VERSION}}/${{steps.get_version.outputs.VERSION}}/g' temp.tmp && cat temp.tmp)
+              line=$(echo "$line" > temp.tmp && sed -i 's/{{env.REPOSITORY_OWNER}}/${{env.REPOSITORY_OWNER}}/g' temp.tmp && cat temp.tmp)
               line=$(echo "$line" > temp.tmp && sed -i 's/{{env.DEFAULT_USER}}/${{env.DEFAULT_USER}}/g' temp.tmp && cat temp.tmp)
               echo "dopo line is $line"
               if [ "$line" == "[sources]" ]
@@ -496,12 +497,12 @@ jobs:
         - name: Tag source images for Ghcr.io
           id: tag-sources-ghcr
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources"
+          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_PREFIX }}${{ steps.get_args.outputs.IMG_NAME }}_sources"
 
         - name: Push source images to Ghcr.io
           id: push-sources-ghcr
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources" 
+          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_PREFIX }}${{ steps.get_args.outputs.IMG_NAME }}_sources" 
 
         - name: Build Docker binaries images
           id: build-binaries
@@ -521,12 +522,12 @@ jobs:
         - name: Tag binaries images for ghcr
           id: tag-binaries-ghcr
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_binaries" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
+          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_binaries" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_PREFIX }}${{ steps.get_args.outputs.IMG_NAME }}_binaries"
         
         - name: Push binaries images to ghcr
           id: push-binaries-ghcr
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
+          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_PREFIX }}${{ steps.get_args.outputs.IMG_NAME }}_binaries"
 
         # - name: Trigger testing pipeline for source image
         #   if: steps.build-sources.outcome == 'success' && steps.push-sources.outcome == 'success' && steps.get_args.outputs.demos_flag_output == 'true' && ! cancelled()
@@ -638,6 +639,7 @@ jobs:
               line=$(echo "$line" > temp.tmp && sed -i 's/{{matrix.apps}}/${{matrix.apps}}/g' temp.tmp && cat temp.tmp)
               line=$(echo "$line" > temp.tmp && sed -i 's/{{matrix.version}}/${{matrix.version}}/g' temp.tmp && cat temp.tmp)
               line=$(echo "$line" > temp.tmp && sed -i 's/{{steps.get_version.outputs.VERSION}}/${{steps.get_version.outputs.VERSION}}/g' temp.tmp && cat temp.tmp)
+              line=$(echo "$line" > temp.tmp && sed -i 's/{{env.REPOSITORY_OWNER}}/${{env.REPOSITORY_OWNER}}/g' temp.tmp && cat temp.tmp)
               line=$(echo "$line" > temp.tmp && sed -i 's/{{env.DEFAULT_USER}}/${{env.DEFAULT_USER}}/g' temp.tmp && cat temp.tmp)
 
               if [ "$line" == "[sources]" ]
@@ -700,7 +702,7 @@ jobs:
                 fi  
                 if [[ $tag_flag != false ]] 
                 then
-                    tag_arg="--tag ${{env.DEFAULT_USER}}/\"$line\""
+                    tag_arg="--tag ${{env.DEFAULT_USER}}/\"$line"
                     img_name="\"$line"
                 fi
               fi
@@ -739,12 +741,12 @@ jobs:
         - name: Tag source images for Ghcr.io
           id: tag-sources-ghcr
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources"
+          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_PREFIX }}${{ steps.get_args.outputs.IMG_NAME }}_sources"
 
         - name: Push source images to Ghcr.io
           id: push-sources-ghcr
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources" 
+          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_PREFIX }}${{ steps.get_args.outputs.IMG_NAME }}_sources" 
 
         - name: Build Docker binaries images
           id: build-binaries
@@ -764,12 +766,12 @@ jobs:
         - name: Tag binaries images for ghcr
           id: tag-binaries-ghcr
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_binaries" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
+          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_binaries" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_PREFIX }}${{ steps.get_args.outputs.IMG_NAME }}_binaries"
         
         - name: Push binaries images to ghcr
           id: push-binaries-ghcr
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
+          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_PREFIX }}${{ steps.get_args.outputs.IMG_NAME }}_binaries"
 
     trigger_children_build:
       runs-on: [ubuntu-latest]

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -8,10 +8,10 @@ on:
             - 'dockerfile_images/**'
     repository_dispatch:
         types: [repository_trigger,robotology_trigger, cron_trigger]
-
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  REPOSITORY_OWNER: ${{ github.repository_owner }}
 
 jobs:
     debug:
@@ -301,7 +301,7 @@ jobs:
         - uses: oprypin/find-latest-tag@v1
           if: matrix.version == 'release'
           with:
-            repository: valegagge/docker-deployment-images-testing
+            repository: ${{ env.IMAGE_NAME }}
             releases-only: true  
           id: release-version
 
@@ -347,7 +347,6 @@ jobs:
             else       
               echo "TAG=$(echo \"-${{matrix.tag}}\" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
             fi
-   
         - name: Get path 
           id: get_path
           run: |            
@@ -465,8 +464,7 @@ jobs:
                 fi  
                 if [[ $tag_flag != false ]] 
                 then
-                    tag_arg="--tag \"$line"
-                    img_name="\"$line"
+                    tag_arg="--tag ${{ env.REPOSITORY_OWNER }}/\"$line"
                 fi
                 if [[ $tag_github_flag != false ]] 
                 then
@@ -479,7 +477,6 @@ jobs:
             echo "SRC_ARGS=$sources_args" >> $GITHUB_OUTPUT
             echo "BIN_ARGS=$binaries_args" >> $GITHUB_OUTPUT
             echo "TAG_ARGS=$tag_arg" >> $GITHUB_OUTPUT
-            echo "IMG_NAME=$img_name" >> $GITHUB_OUTPUT
             echo "IMG_NAME_GITHUB=$img_name_github" >> $GITHUB_OUTPUT
             echo "CMPL_SRC=$compile_sources" >> $GITHUB_OUTPUT
             echo "CMPL_BIN=$compile_binaries" >> $GITHUB_OUTPUT
@@ -500,12 +497,12 @@ jobs:
         - name: Push Docker source images
           id: push-sources
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker push ${{ steps.get_args.outputs.IMG_NAME }}_sources" 
+          run: docker push ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
 
         - name: tag source images for Ghcr.io
           id: tag-sources
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker tag ${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
+          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
 
         - name: Push Docker source images to Ghcr.io
           id: push-sources-ghcr
@@ -520,7 +517,7 @@ jobs:
         - name: Push Docker binaries images
           id: push-binaries
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker push ${{ steps.get_args.outputs.IMG_NAME }}_binaries"
+          run: docker push ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries"
 
         # - name: Trigger testing pipeline for source image
         #   if: steps.build-sources.outcome == 'success' && steps.push-sources.outcome == 'success' && steps.get_args.outputs.demos_flag_output == 'true' && ! cancelled()
@@ -706,8 +703,7 @@ jobs:
                 fi  
                 if [[ $tag_flag != false ]] 
                 then
-                    tag_arg="--tag \"$line"
-                    img_name="\"$line"
+                    tag_arg="--tag ${{ env.REPOSITORY_OWNER }}/\"$line\""
                 fi
                 if [[ $tag_github_flag != false ]] 
                 then
@@ -720,7 +716,6 @@ jobs:
             echo "SRC_ARGS=$sources_args" >> $GITHUB_OUTPUT
             echo "BIN_ARGS=$binaries_args" >> $GITHUB_OUTPUT
             echo "TAG_ARGS=$tag_arg" >> $GITHUB_OUTPUT
-            echo "IMG_NAME=$img_name" >> $GITHUB_OUTPUT
             echo "IMG_NAME_GITHUB=$img_name_github" >> $GITHUB_OUTPUT
             echo "CMPL_SRC=$compile_sources" >> $GITHUB_OUTPUT
             echo "CMPL_BIN=$compile_binaries" >> $GITHUB_OUTPUT
@@ -739,7 +734,7 @@ jobs:
         - name: Push Docker source images
           id: push-sources
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker push ${{ steps.get_args.outputs.IMG_NAME }}_sources" 
+          run: docker push ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
 
         - name: Build Docker binaries images
           id: build-binaries
@@ -749,7 +744,7 @@ jobs:
         - name: Push Docker binaries images
           id: push-binaries
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker push ${{ steps.get_args.outputs.IMG_NAME }}_binaries"
+          run: docker push ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries"
  
         # - name: Trigger testing pipeline for source image
         #   if: steps.build-sources.outcome == 'success' && steps.push-sources.outcome == 'success' && steps.get_args.outputs.demos_flag_output == 'true' && ! cancelled()

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -10,7 +10,7 @@ on:
         types: [repository_trigger,robotology_trigger, cron_trigger]
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  REPOSITORY_NAME: ${{ github.repository }}
   REPOSITORY_OWNER: ${{ github.repository_owner }}
 
 jobs:
@@ -301,7 +301,7 @@ jobs:
         - uses: oprypin/find-latest-tag@v1
           if: matrix.version == 'release'
           with:
-            repository: ${{ env.IMAGE_NAME }}
+            repository: ${{ env.REPOSITORY_NAME }}
             releases-only: true  
           id: release-version
 
@@ -502,12 +502,12 @@ jobs:
         - name: tag source images for Ghcr.io
           id: tag-sources
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
+          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
 
         - name: Push Docker source images to Ghcr.io
           id: push-sources-ghcr
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
+          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
 
         - name: Build Docker binaries images
           id: build-binaries
@@ -776,7 +776,7 @@ jobs:
           uses: peter-evans/repository-dispatch@v1
           with:
             token: ${{ secrets.GITHUB_TOKEN  }}
-            repository: ${{ env.IMAGE_NAME }}
+            repository: ${{ env.REPOSITORY_NAME }}
             event-type: repository_trigger
             client-payload: '{"version": "${{ github.event.client_payload.version }}", "type": "repository_trigger", "img_list": "${{ needs.check_files.outputs.children_matrix }}"}'
             
@@ -786,7 +786,7 @@ jobs:
           uses: peter-evans/repository-dispatch@v1
           with:
             token: ${{ secrets.GITHUB_TOKEN  }}
-            repository: ${{ env.IMAGE_NAME }}
+            repository: ${{ env.REPOSITORY_NAME }}
             event-type: cron_trigger
             client-payload: '{"type": "cron_trigger", "img_list": "${{ needs.check_files.outputs.children_matrix }}"}'
 

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -13,6 +13,7 @@ env:
   REPOSITORY_NAME: ${{ github.repository }}
   REPOSITORY_OWNER: ${{ github.repository_owner }}
   DOCKERHUB_OWNER: ${{ secrets.DOCKERHUB_USERNAME }}
+  DEFAULT_USER: defaultuser
 
 jobs:
     debug:
@@ -383,7 +384,7 @@ jobs:
             echo "{{matrix.version}} - ${{matrix.version}}"
             echo "{{matrix.apps}} - ${{matrix.apps}}"
             echo "{{steps.get_version.outputs.VERSION}} - ${{steps.get_version.outputs.VERSION}}"
-            echo "{{env.REPOSITORY_OWNER}} - ${{env.REPOSITORY_OWNER}}"
+            echo "{{env.DEFAULT_USER}} - ${{env.DEFAULT_USER}}"
             while read -r line || [ -n "$line" ]
             do
               echo "line is $line"
@@ -392,7 +393,7 @@ jobs:
               line=$(echo "$line" > temp.tmp && sed -i 's/{{matrix.version}}/${{matrix.version}}/g' temp.tmp && cat temp.tmp)
               line=$(echo "$line" > temp.tmp && sed -i 's/{{matrix.apps}}/${{matrix.apps}}/g' temp.tmp && cat temp.tmp)
               line=$(echo "$line" > temp.tmp && sed -i 's/{{steps.get_version.outputs.VERSION}}/${{steps.get_version.outputs.VERSION}}/g' temp.tmp && cat temp.tmp)
-              line=$(echo "$line" > temp.tmp && sed -i 's/{{env.REPOSITORY_OWNER}}/${{env.REPOSITORY_OWNER}}/g' temp.tmp && cat temp.tmp)
+              line=$(echo "$line" > temp.tmp && sed -i 's/{{env.DEFAULT_USER}}/${{env.DEFAULT_USER}}/g' temp.tmp && cat temp.tmp)
               echo "dopo line is $line"
               if [ "$line" == "[sources]" ]
               then
@@ -454,7 +455,7 @@ jobs:
                 fi  
                 if [[ $tag_flag != false ]] 
                 then
-                    tag_arg="--tag ${{env.REPOSITORY_OWNER}}/\"$line"
+                    tag_arg="--tag ${{env.DEFAULT_USER}}/\"$line"
                     img_name="\"$line"
                 fi
               fi
@@ -484,7 +485,7 @@ jobs:
         - name: Tag source images for dockerhub
           id: tag-sources-dockerhub
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources"
+          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources"
 
         - name: Push Docker source images
           id: push-sources-dockerhub
@@ -494,7 +495,7 @@ jobs:
         - name: Tag source images for Ghcr.io
           id: tag-sources-ghcr
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources"
+          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources"
 
         - name: Push source images to Ghcr.io
           id: push-sources-ghcr
@@ -509,7 +510,7 @@ jobs:
         - name: Tag binaries images for dockerhub
           id: tag-binaries-dockerhub
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME }}_binaries" ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
+          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_binaries" ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
         
         - name: Push Docker binaries images
           id: push-binaries-dockerhub
@@ -519,7 +520,7 @@ jobs:
         - name: Tag binaries images for ghcr
           id: tag-binaries-ghcr
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME }}_binaries" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
+          run: docker tag ${{env.DEFAULT_USER}}/${{ steps.get_args.outputs.IMG_NAME }}_binaries" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
         
         - name: Push binaries images to ghcr
           id: push-binaries-ghcr
@@ -723,6 +724,7 @@ jobs:
             echo "cmpl sources: $compile_sources"
             echo "cmpl binaries: $compile_binaries"
             echo "cmpl tag: $tag_arg"
+
         - name: Build Docker sources images
           id: build-sources
           if: steps.get_args.outputs.CMPL_SRC == 'true'

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -14,7 +14,7 @@ env:
   REPOSITORY_OWNER: ${{ github.repository_owner }}
   DOCKERHUB_OWNER: ${{ secrets.DOCKERHUB_USERNAME }}
   DEFAULT_USER: defaultuser
-  IMAGE_PREFIX: sw_deployments_
+  IMAGE_PREFIX: cd_
 
 jobs:
     debug:

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -464,7 +464,7 @@ jobs:
                 fi  
                 if [[ $tag_flag != false ]] 
                 then
-                    tag_arg="--tag ${{ env.REPOSITORY_OWNER }}/\"$line"
+                    tag_arg="--tag fakerepo/\"$line"
                 fi
                 if [[ $tag_github_flag != false ]] 
                 then
@@ -494,10 +494,15 @@ jobs:
           if: steps.get_args.outputs.CMPL_SRC == 'true'
           run: docker build ${{ steps.get_args.outputs.SRC_ARGS }} --no-cache ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}} --file ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}}/Dockerfile ${{ steps.get_args.outputs.TAG_ARGS }}_sources" 
 
+        - name: tag source images for dockerhub
+          id: tag-sources-dockerhub
+          if: steps.get_args.outputs.CMPL_SRC == 'true'
+          run: docker tag fakerepo/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
+
         - name: Push Docker source images
           id: push-sources
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker push ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
+          run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
 
         - name: tag source images for Ghcr.io
           id: tag-sources

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -30,7 +30,7 @@ jobs:
       steps: 
       - id: file_changes
         if: github.event_name == 'push'
-        uses: trilom/file-changes-action@v1.2.3
+        uses: trilom/file-changes-action@v1.2.4
       - name: files
         if: github.event_name == 'push'
         id: check-modifications
@@ -41,7 +41,7 @@ jobs:
           echo '${{ steps.file_changes.outputs.files}}'
           echo '${{ steps.file_changes.outputs.files_modified}}'
           echo '${{ steps.file_changes.outputs.files_added}}'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: find app name
         id: set-matrix
         run: |
@@ -170,7 +170,7 @@ jobs:
                       else
                           custom_matrix="$custom_matrix $element"
                       fi
-                  fi                
+                  fi
               fi
           done
           children_matrix="$children_matrix"
@@ -302,12 +302,12 @@ jobs:
           id: release-version
 
   ##################### check out the correct version (master or release) ###############
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           if: matrix.version == 'master'
           with:
             ref: 'master'
 
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           if: matrix.version == 'release'
           with:
             ref: '${{ steps.release-version.outputs.tag }}'
@@ -366,6 +366,7 @@ jobs:
             sources_flag=false
             binaries_flag=false
             tag_flag=false
+            tag_github_flag=false
             compile_sources=false
             compile_binaries=false
             demos_matrix=""
@@ -392,6 +393,7 @@ jobs:
                   sources_flag=true
                   binaries_flag=false
                   tag_flag=false
+                  tag_github_flag=false
                   compile_sources=true
                   demos_flag=false
               fi
@@ -400,6 +402,7 @@ jobs:
                   sources_flag=false
                   binaries_flag=true
                   tag_flag=false
+                  tag_github_flag=false
                   compile_binaries=true
                   demos_flag=false
               fi
@@ -408,6 +411,15 @@ jobs:
                   sources_flag=false
                   binaries_flag=false
                   tag_flag=true
+                  tag_github_flag=false
+                  demos_flag=false
+              fi
+              if [ "$line" == "[tag-github]" ]
+              then
+                  sources_flag=false
+                  binaries_flag=false
+                  tag_flag=false
+                  tag_github_flag=true
                   demos_flag=false
               fi
               if [ "$line" == "[children]" ]
@@ -415,6 +427,7 @@ jobs:
                   sources_flag=false
                   binaries_flag=false
                   tag_flag=false
+                  tag_github_flag=false
                   demos_flag=false
               fi
               if [ $demos_flag == true ]
@@ -433,9 +446,10 @@ jobs:
                   sources_flag=false
                   binaries_flag=false
                   tag_flag=false
+                  tag_github_flag=false
                   demos_flag=true
               fi
-              if [ "$line" != "[sources]" ] && [ "$line" != "[binaries]" ] && [ "$line" != "[tag]" ] && [ "$line" != "[superbuild]" ] && [ "$line" != "[children]" ] && [ "$line" != "[demos]" ] &&  [  "$line" != ""  ]
+              if [ "$line" != "[sources]" ] && [ "$line" != "[binaries]" ] && [ "$line" != "[tag]" ] && [ "$line" != "[tag-github]" ] && [ "$line" != "[superbuild]" ] && [ "$line" != "[children]" ] && [ "$line" != "[demos]" ] &&  [  "$line" != ""  ]
               then
                 if [[ $sources_flag != false ]]
                 then
@@ -450,6 +464,10 @@ jobs:
                     tag_arg="--tag \"$line"
                     img_name="\"$line"
                 fi
+                if [[ $tag_github_flag != false ]] 
+                then
+                    img_name_github="\"$line"
+                fi
               fi
             done < ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}}/conf_build.ini
             demos_matrix=$(echo "${demos_matrix[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
@@ -458,6 +476,7 @@ jobs:
             echo "BIN_ARGS=$binaries_args" >> $GITHUB_OUTPUT
             echo "TAG_ARGS=$tag_arg" >> $GITHUB_OUTPUT
             echo "IMG_NAME=$img_name" >> $GITHUB_OUTPUT
+            echo "IMG_NAME_GITHUB=$img_name_github" >> $GITHUB_OUTPUT
             echo "CMPL_SRC=$compile_sources" >> $GITHUB_OUTPUT
             echo "CMPL_BIN=$compile_binaries" >> $GITHUB_OUTPUT
             echo "demos_matrix=${demos_matrix[@]}" >> $GITHUB_OUTPUT
@@ -468,6 +487,7 @@ jobs:
             echo "cmpl binaries: $compile_binaries"
             echo "cmpl tag: $tag_arg"
             echo "demo matrix: ${demos_matrix[@]}"
+
         - name: Build Docker sources images
           id: build-sources
           if: steps.get_args.outputs.CMPL_SRC == 'true'
@@ -481,12 +501,12 @@ jobs:
         - name: tag source images for Ghcr.io
           id: tag-sources
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker tag ${{ steps.get_args.outputs.IMG_NAME }}_sources" ghcr.io/MSECode/${{ steps.get_args.outputs.IMG_NAME }}_sources
+          run: docker tag ${{ steps.get_args.outputs.IMG_NAME }}_sources" ghcr.io/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
 
         - name: Push Docker source images to Ghcr.io
           id: push-sources-ghcr
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker push ghcr.io/MSECode/${{ steps.get_args.outputs.IMG_NAME }}_sources" 
+          run: docker push ghcr.io/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
 
         - name: Build Docker binaries images
           id: build-binaries
@@ -544,12 +564,12 @@ jobs:
           id: release-version
 
   ##################### check out the correct version (master or release) ###############
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           if: matrix.version == 'master'
           with:
             ref: 'master'
 
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           if: matrix.version == 'release'
           with:
             ref: '${{ steps.release-version.outputs.tag }}'
@@ -597,6 +617,7 @@ jobs:
             sources_flag=false
             binaries_flag=false
             tag_flag=false
+            tag_github_flag=false
             compile_sources=false
             compile_binaries=false
             demos_matrix=""
@@ -613,6 +634,7 @@ jobs:
                   sources_flag=true
                   binaries_flag=false
                   tag_flag=false
+                  tag_github_flag=false
                   compile_sources=true
                   demos_flag=false
               fi
@@ -621,6 +643,7 @@ jobs:
                   sources_flag=false
                   binaries_flag=true
                   tag_flag=false
+                  tag_github_flag=false
                   compile_binaries=true
                   demos_flag=false
               fi
@@ -629,6 +652,15 @@ jobs:
                   sources_flag=false
                   binaries_flag=false
                   tag_flag=true
+                  tag_github_flag=false
+                  demos_flag=false
+              fi
+              if [ "$line" == "[tag-github]" ]
+              then
+                  sources_flag=false
+                  binaries_flag=false
+                  tag_flag=false
+                  tag_github_flag=true
                   demos_flag=false
               fi
               if [ "$line" == "[children]" ]
@@ -636,6 +668,7 @@ jobs:
                   sources_flag=false
                   binaries_flag=false
                   tag_flag=false
+                  tag_github_flag=false
                   demos_flag=false
               fi
               if [ $demos_flag == true ]
@@ -654,9 +687,10 @@ jobs:
                   sources_flag=false
                   binaries_flag=false
                   tag_flag=false
+                  tag_github_flag=false
                   demos_flag=true
               fi
-              if [ "$line" != "[sources]" ] && [ "$line" != "[binaries]" ] && [ "$line" != "[tag]" ] && [ "$line" != "[superbuild]" ] && [ "$line" != "[children]" ] && [ "$line" != "[demos]" ] &&  [  "$line" != ""  ]
+              if [ "$line" != "[sources]" ] && [ "$line" != "[binaries]" ] && [ "$line" != "[tag]" ] && [ "$line" != "[tag-github]" ] && [ "$line" != "[superbuild]" ] && [ "$line" != "[children]" ] && [ "$line" != "[demos]" ] &&  [  "$line" != ""  ]
               then
                 if [[ $sources_flag != false ]]
                 then
@@ -671,6 +705,10 @@ jobs:
                     tag_arg="--tag \"$line"
                     img_name="\"$line"
                 fi
+                if [[ $tag_github_flag != false ]] 
+                then
+                    img_name_github="\"$line"
+                fi
               fi
             done < ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}}/conf_build.ini
             demos_matrix=$(echo "${demos_matrix[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
@@ -679,6 +717,7 @@ jobs:
             echo "BIN_ARGS=$binaries_args" >> $GITHUB_OUTPUT
             echo "TAG_ARGS=$tag_arg" >> $GITHUB_OUTPUT
             echo "IMG_NAME=$img_name" >> $GITHUB_OUTPUT
+            echo "IMG_NAME_GITHUB=$img_name_github" >> $GITHUB_OUTPUT
             echo "CMPL_SRC=$compile_sources" >> $GITHUB_OUTPUT
             echo "CMPL_BIN=$compile_binaries" >> $GITHUB_OUTPUT
             echo "demos_matrix=${demos_matrix[@]}" >> $GITHUB_OUTPUT

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
     debug:
@@ -301,7 +300,7 @@ jobs:
         - uses: oprypin/find-latest-tag@v1
           if: matrix.version == 'release'
           with:
-            repository: ${{ env.IMAGE_NAME }}
+            repository: valegagge/docker-deployment-images-testing
             releases-only: true  
           id: release-version
 
@@ -505,12 +504,12 @@ jobs:
         - name: tag source images for Ghcr.io
           id: tag-sources
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker tag ${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ env.REGISTRY }}/${{env.IMAGE_NAME}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
+          run: docker tag ${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ env.REGISTRY }}/${{ github.repository }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
 
         - name: Push Docker source images to Ghcr.io
           id: push-sources-ghcr
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
+          run: docker push ${{ env.REGISTRY }}/${{ github.repository }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
 
         - name: Build Docker binaries images
           id: build-binaries
@@ -563,7 +562,7 @@ jobs:
         - uses: oprypin/find-latest-tag@v1
           if: matrix.version == 'release'
           with:
-            repository: {{ env.IMAGE_NAME }}
+            repository: valegagge/docker-deployment-images-testing
             releases-only: true  
           id: release-version
 
@@ -756,7 +755,7 @@ jobs:
         #   uses: peter-evans/repository-dispatch@v1
         #   with:
         #     token: ${{ secrets.GITHUB_TOKEN  }}
-        #     repository: {{ env.IMAGE_NAME }}
+        #     repository: valegagge/docker-deployment-images-testing
         #     event-type: app_testing_from_code
         #     client-payload: '{"type": "app_testing_from_code", "app_list": "${{ steps.get_args.outputs.demos_matrix }}", "img_list": "icubteamcode/${{matrix.apps}}", "version_list": "master", "tag_list": "sources", "children_flag": ${{needs.check_files.outputs.children_flag}} }'
 
@@ -765,7 +764,7 @@ jobs:
         #   uses: peter-evans/repository-dispatch@v1
         #   with:
         #     token: ${{ secrets.GITHUB_TOKEN  }}
-        #     repository: {{ env.IMAGE_NAME }}
+        #     repository: valegagge/docker-deployment-images-testing
         #     event-type: app_testing_from_code
         #     client-payload: '{"type": "app_testing_from_code", "app_list": "${{ steps.get_args.outputs.demos_matrix }}", "img_list": "icubteamcode/${{matrix.apps}}", "version_list": "master", "tag_list": "binaries", "children_flag": ${{needs.check_files.outputs.children_flag}} }'
         
@@ -781,7 +780,7 @@ jobs:
           uses: peter-evans/repository-dispatch@v1
           with:
             token: ${{ secrets.GITHUB_TOKEN  }}
-            repository: {{ env.IMAGE_NAME }}
+            repository: valegagge/docker-deployment-images-testing
             event-type: repository_trigger
             client-payload: '{"version": "${{ github.event.client_payload.version }}", "type": "repository_trigger", "img_list": "${{ needs.check_files.outputs.children_matrix }}"}'
             
@@ -791,7 +790,7 @@ jobs:
           uses: peter-evans/repository-dispatch@v1
           with:
             token: ${{ secrets.GITHUB_TOKEN  }}
-            repository: {{ env.IMAGE_NAME }}
+            repository: valegagge/docker-deployment-images-testing
             event-type: cron_trigger
             client-payload: '{"type": "cron_trigger", "img_list": "${{ needs.check_files.outputs.children_matrix }}"}'
 

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -399,7 +399,6 @@ jobs:
                   sources_flag=true
                   binaries_flag=false
                   tag_flag=false
-                  tag_github_flag=false
                   compile_sources=true
                   demos_flag=false
               fi
@@ -408,7 +407,6 @@ jobs:
                   sources_flag=false
                   binaries_flag=true
                   tag_flag=false
-                  tag_github_flag=false
                   compile_binaries=true
                   demos_flag=false
               fi
@@ -417,15 +415,6 @@ jobs:
                   sources_flag=false
                   binaries_flag=false
                   tag_flag=true
-                  tag_github_flag=false
-                  demos_flag=false
-              fi
-              if [ "$line" == "[tag-github]" ]
-              then
-                  sources_flag=false
-                  binaries_flag=false
-                  tag_flag=false
-                  tag_github_flag=true
                   demos_flag=false
               fi
               if [ "$line" == "[children]" ]
@@ -433,7 +422,6 @@ jobs:
                   sources_flag=false
                   binaries_flag=false
                   tag_flag=false
-                  tag_github_flag=false
                   demos_flag=false
               fi
               if [ $demos_flag == true ]
@@ -452,7 +440,6 @@ jobs:
                   sources_flag=false
                   binaries_flag=false
                   tag_flag=false
-                  tag_github_flag=false
                   demos_flag=true
               fi
               if [ "$line" != "[sources]" ] && [ "$line" != "[binaries]" ] && [ "$line" != "[tag]" ] && [ "$line" != "[tag-github]" ] && [ "$line" != "[superbuild]" ] && [ "$line" != "[children]" ] && [ "$line" != "[demos]" ] &&  [  "$line" != ""  ]
@@ -468,10 +455,7 @@ jobs:
                 if [[ $tag_flag != false ]] 
                 then
                     tag_arg="--tag ${{env.REPOSITORY_OWNER}}/\"$line"
-                fi
-                if [[ $tag_github_flag != false ]] 
-                then
-                    img_name_github="\"$line"
+                    img_name="\"$line"
                 fi
               fi
             done < ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}}/conf_build.ini
@@ -480,7 +464,7 @@ jobs:
             echo "SRC_ARGS=$sources_args" >> $GITHUB_OUTPUT
             echo "BIN_ARGS=$binaries_args" >> $GITHUB_OUTPUT
             echo "TAG_ARGS=$tag_arg" >> $GITHUB_OUTPUT
-            echo "IMG_NAME_GITHUB=$img_name_github" >> $GITHUB_OUTPUT
+            echo "IMG_NAME=$img_name" >> $GITHUB_OUTPUT
             echo "CMPL_SRC=$compile_sources" >> $GITHUB_OUTPUT
             echo "CMPL_BIN=$compile_binaries" >> $GITHUB_OUTPUT
             echo "demos_matrix=${demos_matrix[@]}" >> $GITHUB_OUTPUT
@@ -500,22 +484,22 @@ jobs:
         - name: Tag source images for dockerhub
           id: tag-sources-dockerhub
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
+          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources"
 
         - name: Push Docker source images
           id: push-sources-dockerhub
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
+          run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources" 
 
         - name: Tag source images for Ghcr.io
           id: tag-sources-ghcr
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
+          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME }}_sources" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources"
 
         - name: Push source images to Ghcr.io
           id: push-sources-ghcr
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
+          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_sources" 
 
         - name: Build Docker binaries images
           id: build-binaries
@@ -525,22 +509,22 @@ jobs:
         - name: Tag binaries images for dockerhub
           id: tag-binaries-dockerhub
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries" ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries"
+          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME }}_binaries" ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
         
         - name: Push Docker binaries images
           id: push-binaries-dockerhub
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries"
+          run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
 
         - name: Tag binaries images for ghcr
           id: tag-binaries-ghcr
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries"
+          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME }}_binaries" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
         
         - name: Push binaries images to ghcr
           id: push-binaries-ghcr
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries"
+          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
 
         # - name: Trigger testing pipeline for source image
         #   if: steps.build-sources.outcome == 'success' && steps.push-sources.outcome == 'success' && steps.get_args.outputs.demos_flag_output == 'true' && ! cancelled()
@@ -641,7 +625,6 @@ jobs:
             sources_flag=false
             binaries_flag=false
             tag_flag=false
-            tag_github_flag=false
             compile_sources=false
             compile_binaries=false
             demos_matrix=""
@@ -658,7 +641,6 @@ jobs:
                   sources_flag=true
                   binaries_flag=false
                   tag_flag=false
-                  tag_github_flag=false
                   compile_sources=true
                   demos_flag=false
               fi
@@ -667,7 +649,6 @@ jobs:
                   sources_flag=false
                   binaries_flag=true
                   tag_flag=false
-                  tag_github_flag=false
                   compile_binaries=true
                   demos_flag=false
               fi
@@ -676,7 +657,6 @@ jobs:
                   sources_flag=false
                   binaries_flag=false
                   tag_flag=true
-                  tag_github_flag=false
                   demos_flag=false
               fi
               if [ "$line" == "[tag-github]" ]
@@ -684,7 +664,6 @@ jobs:
                   sources_flag=false
                   binaries_flag=false
                   tag_flag=false
-                  tag_github_flag=true
                   demos_flag=false
               fi
               if [ "$line" == "[children]" ]
@@ -692,7 +671,6 @@ jobs:
                   sources_flag=false
                   binaries_flag=false
                   tag_flag=false
-                  tag_github_flag=false
                   demos_flag=false
               fi
               if [ $demos_flag == true ]
@@ -711,7 +689,6 @@ jobs:
                   sources_flag=false
                   binaries_flag=false
                   tag_flag=false
-                  tag_github_flag=false
                   demos_flag=true
               fi
               if [ "$line" != "[sources]" ] && [ "$line" != "[binaries]" ] && [ "$line" != "[tag]" ] && [ "$line" != "[tag-github]" ] && [ "$line" != "[superbuild]" ] && [ "$line" != "[children]" ] && [ "$line" != "[demos]" ] &&  [  "$line" != ""  ]
@@ -727,10 +704,7 @@ jobs:
                 if [[ $tag_flag != false ]] 
                 then
                     tag_arg="--tag ${{ env.REPOSITORY_OWNER }}/\"$line\""
-                fi
-                if [[ $tag_github_flag != false ]] 
-                then
-                    img_name_github="\"$line"
+                    img_name="\"$line"
                 fi
               fi
             done < ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}}/conf_build.ini
@@ -739,7 +713,7 @@ jobs:
             echo "SRC_ARGS=$sources_args" >> $GITHUB_OUTPUT
             echo "BIN_ARGS=$binaries_args" >> $GITHUB_OUTPUT
             echo "TAG_ARGS=$tag_arg" >> $GITHUB_OUTPUT
-            echo "IMG_NAME_GITHUB=$img_name_github" >> $GITHUB_OUTPUT
+            echo "IMG_NAME=$img_name" >> $GITHUB_OUTPUT
             echo "CMPL_SRC=$compile_sources" >> $GITHUB_OUTPUT
             echo "CMPL_BIN=$compile_binaries" >> $GITHUB_OUTPUT
             echo "demos_matrix=${demos_matrix[@]}" >> $GITHUB_OUTPUT
@@ -757,7 +731,7 @@ jobs:
         - name: Push Docker source images
           id: push-sources
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker push ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
+          run: docker push ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME }}_sources" 
 
         - name: Build Docker binaries images
           id: build-binaries
@@ -767,7 +741,7 @@ jobs:
         - name: Push Docker binaries images
           id: push-binaries
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker push ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries"
+          run: docker push ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME }}_binaries"
  
         # - name: Trigger testing pipeline for source image
         #   if: steps.build-sources.outcome == 'success' && steps.push-sources.outcome == 'success' && steps.get_args.outputs.demos_flag_output == 'true' && ! cancelled()

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -12,6 +12,7 @@ env:
   REGISTRY: ghcr.io
   REPOSITORY_NAME: ${{ github.repository }}
   REPOSITORY_OWNER: ${{ github.repository_owner }}
+  DOCKERHUB_OWNER: ${{ secrets.DOCKERHUB_USERNAME }}
 
 jobs:
     debug:
@@ -25,8 +26,6 @@ jobs:
       - id: get_version
         run: |
           echo "I received the version: ${{ github.event.client_payload.version }}"
-
-      
 
     check_files:
       runs-on: [ubuntu-latest]
@@ -322,11 +321,11 @@ jobs:
           run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
   
   #########################################################################################        
-        - name: Log in to the Container registry          
-          uses: docker/login-action@v2.0.0          
-          with:            
-            registry: ghcr.io            
-            username: ${{ github.actor }}            
+        - name: Log in to the Container registry
+          uses: docker/login-action@v2.0.0
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }} 
 
   ##################### Command to set the tag for the date argument ######################
@@ -363,6 +362,8 @@ jobs:
         - name: Get Build Arguments
           id: get_args
           run: |
+            start_img=""
+            source_img=""
             sources_args=""
             binaries_args=""
             tag_arg=""
@@ -382,6 +383,7 @@ jobs:
             echo "{{matrix.version}} - ${{matrix.version}}"
             echo "{{matrix.apps}} - ${{matrix.apps}}"
             echo "{{steps.get_version.outputs.VERSION}} - ${{steps.get_version.outputs.VERSION}}"
+            echo "{{env.REPOSITORY_OWNER}} - ${{env.REPOSITORY_OWNER}}"
             while read -r line || [ -n "$line" ]
             do
               echo "line is $line"
@@ -390,6 +392,7 @@ jobs:
               line=$(echo "$line" > temp.tmp && sed -i 's/{{matrix.version}}/${{matrix.version}}/g' temp.tmp && cat temp.tmp)
               line=$(echo "$line" > temp.tmp && sed -i 's/{{matrix.apps}}/${{matrix.apps}}/g' temp.tmp && cat temp.tmp)
               line=$(echo "$line" > temp.tmp && sed -i 's/{{steps.get_version.outputs.VERSION}}/${{steps.get_version.outputs.VERSION}}/g' temp.tmp && cat temp.tmp)
+              line=$(echo "$line" > temp.tmp && sed -i 's/{{env.REPOSITORY_OWNER}}/${{env.REPOSITORY_OWNER}}/g' temp.tmp && cat temp.tmp)
               echo "dopo line is $line"
               if [ "$line" == "[sources]" ]
               then
@@ -464,7 +467,7 @@ jobs:
                 fi  
                 if [[ $tag_flag != false ]] 
                 then
-                    tag_arg="--tag fakerepo/\"$line"
+                    tag_arg="--tag ${{env.REPOSITORY_OWNER}}/\"$line"
                 fi
                 if [[ $tag_github_flag != false ]] 
                 then
@@ -494,22 +497,22 @@ jobs:
           if: steps.get_args.outputs.CMPL_SRC == 'true'
           run: docker build ${{ steps.get_args.outputs.SRC_ARGS }} --no-cache ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}} --file ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}}/Dockerfile ${{ steps.get_args.outputs.TAG_ARGS }}_sources" 
 
-        - name: tag source images for dockerhub
+        - name: Tag source images for dockerhub
           id: tag-sources-dockerhub
           if: steps.get_args.outputs.CMPL_SRC == 'true'
-          run: docker tag fakerepo/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
+          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
 
         - name: Push Docker source images
-          id: push-sources
+          id: push-sources-dockerhub
           if: steps.get_args.outputs.CMPL_SRC == 'true'
           run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
 
-        - name: tag source images for Ghcr.io
-          id: tag-sources
+        - name: Tag source images for Ghcr.io
+          id: tag-sources-ghcr
           if: steps.get_args.outputs.CMPL_SRC == 'true'
           run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources"
 
-        - name: Push Docker source images to Ghcr.io
+        - name: Push source images to Ghcr.io
           id: push-sources-ghcr
           if: steps.get_args.outputs.CMPL_SRC == 'true'
           run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_sources" 
@@ -519,10 +522,25 @@ jobs:
           if: steps.get_args.outputs.CMPL_BIN == 'true'
           run: docker build  ${{ steps.get_args.outputs.BIN_ARGS }} --no-cache ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}} --file ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}}/Dockerfile4Production ${{ steps.get_args.outputs.TAG_ARGS }}_binaries" 
 
-        - name: Push Docker binaries images
-          id: push-binaries
+        - name: Tag binaries images for dockerhub
+          id: tag-binaries-dockerhub
           if: steps.get_args.outputs.CMPL_BIN == 'true'
-          run: docker push ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries"
+          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries" ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries"
+        
+        - name: Push Docker binaries images
+          id: push-binaries-dockerhub
+          if: steps.get_args.outputs.CMPL_BIN == 'true'
+          run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries"
+
+        - name: Tag binaries images for ghcr
+          id: tag-binaries-ghcr
+          if: steps.get_args.outputs.CMPL_BIN == 'true'
+          run: docker tag ${{env.REPOSITORY_OWNER}}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries" ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries"
+        
+        - name: Push binaries images to ghcr
+          id: push-binaries-ghcr
+          if: steps.get_args.outputs.CMPL_BIN == 'true'
+          run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ steps.get_args.outputs.IMG_NAME_GITHUB }}_binaries"
 
         # - name: Trigger testing pipeline for source image
         #   if: steps.build-sources.outcome == 'success' && steps.push-sources.outcome == 'success' && steps.get_args.outputs.demos_flag_output == 'true' && ! cancelled()

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -297,7 +297,7 @@ jobs:
         - uses: oprypin/find-latest-tag@v1
           if: matrix.version == 'release'
           with:
-            repository: icub-tech-iit/docker-deployment-images
+            repository: MSECode/docker-deployment-images-testing
             releases-only: true  
           id: release-version
 
@@ -316,6 +316,14 @@ jobs:
 
         - name: Login to DockerHub Registry
           run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+  
+  #########################################################################################        
+        - name: Log in to the Container registry          
+          uses: docker/login-action@v2.0.0          
+          with:            
+            registry: ghcr.io            
+            username: ${{ github.actor }}            
+            password: ${{ secrets.GITHUB_TOKEN }} 
 
   ##################### Command to set the tag for the date argument ######################
         - name: set date argument for Docker build
@@ -470,6 +478,16 @@ jobs:
           if: steps.get_args.outputs.CMPL_SRC == 'true'
           run: docker push ${{ steps.get_args.outputs.IMG_NAME }}_sources" 
 
+        - name: tag source images for Ghcr.io
+          id: tag-sources
+          if: steps.get_args.outputs.CMPL_SRC == 'true'
+          run: docker tag ${{ steps.get_args.outputs.IMG_NAME }}_sources" ghcr.io/MSECode/${{ steps.get_args.outputs.IMG_NAME }}_sources
+
+        - name: Push Docker source images to Ghcr.io
+          id: push-sources-ghcr
+          if: steps.get_args.outputs.CMPL_SRC == 'true'
+          run: docker push ghcr.io/MSECode/${{ steps.get_args.outputs.IMG_NAME }}_sources" 
+
         - name: Build Docker binaries images
           id: build-binaries
           if: steps.get_args.outputs.CMPL_BIN == 'true'
@@ -485,7 +503,7 @@ jobs:
         #   uses: peter-evans/repository-dispatch@v1
         #   with:
         #     token: ${{ secrets.GITHUB_TOKEN  }}
-        #     repository: icub-tech-iit/docker-deployment-images
+        #     repository: MSECode/docker-deployment-images-testing
         #     event-type: app_testing_from_code
         #     client-payload: '{"type": "app_testing_from_code", "app_list": "${{ steps.get_args.outputs.demos_matrix }}", "img_list": "icubteamcode/${{matrix.apps}}", "version_list": ${{steps.get_version.outputs.VERSION}}-${{steps.get_version.outputs.TAG}}, "tag_list": "sources", "children_flag": ${{needs.check_files.outputs.children_flag}}}'
 
@@ -494,7 +512,7 @@ jobs:
         #   uses: peter-evans/repository-dispatch@v1
         #   with:
         #     token: ${{ secrets.GITHUB_TOKEN  }}
-        #     repository: icub-tech-iit/docker-deployment-images
+        #     repository: MSECode/docker-deployment-images-testing
         #     event-type: app_testing_from_code
         #     client-payload: '{"type": "app_testing_from_code", "app_list": "${{ steps.get_args.outputs.demos_matrix }}","img_list": "icubteamcode/${{matrix.apps}}", "version_list": ${{steps.get_version.outputs.VERSION}}-${{steps.get_version.outputs.TAG}}, "tag_list": "binaries", "children_flag": ${{needs.check_files.outputs.children_flag}}}'
           
@@ -521,7 +539,7 @@ jobs:
         - uses: oprypin/find-latest-tag@v1
           if: matrix.version == 'release'
           with:
-            repository: icub-tech-iit/docker-deployment-images
+            repository: MSECode/docker-deployment-images-testing
             releases-only: true  
           id: release-version
 
@@ -695,7 +713,7 @@ jobs:
         #   uses: peter-evans/repository-dispatch@v1
         #   with:
         #     token: ${{ secrets.GITHUB_TOKEN  }}
-        #     repository: icub-tech-iit/docker-deployment-images
+        #     repository: MSECode/docker-deployment-images-testing
         #     event-type: app_testing_from_code
         #     client-payload: '{"type": "app_testing_from_code", "app_list": "${{ steps.get_args.outputs.demos_matrix }}", "img_list": "icubteamcode/${{matrix.apps}}", "version_list": "master", "tag_list": "sources", "children_flag": ${{needs.check_files.outputs.children_flag}} }'
 
@@ -704,7 +722,7 @@ jobs:
         #   uses: peter-evans/repository-dispatch@v1
         #   with:
         #     token: ${{ secrets.GITHUB_TOKEN  }}
-        #     repository: icub-tech-iit/docker-deployment-images
+        #     repository: MSECode/docker-deployment-images-testing
         #     event-type: app_testing_from_code
         #     client-payload: '{"type": "app_testing_from_code", "app_list": "${{ steps.get_args.outputs.demos_matrix }}", "img_list": "icubteamcode/${{matrix.apps}}", "version_list": "master", "tag_list": "binaries", "children_flag": ${{needs.check_files.outputs.children_flag}} }'
         
@@ -720,7 +738,7 @@ jobs:
           uses: peter-evans/repository-dispatch@v1
           with:
             token: ${{ secrets.GITHUB_TOKEN  }}
-            repository: icub-tech-iit/docker-deployment-images
+            repository: MSECode/docker-deployment-images-testing
             event-type: repository_trigger
             client-payload: '{"version": "${{ github.event.client_payload.version }}", "type": "repository_trigger", "img_list": "${{ needs.check_files.outputs.children_matrix }}"}'
             
@@ -730,7 +748,7 @@ jobs:
           uses: peter-evans/repository-dispatch@v1
           with:
             token: ${{ secrets.GITHUB_TOKEN  }}
-            repository: icub-tech-iit/docker-deployment-images
+            repository: MSECode/docker-deployment-images-testing
             event-type: cron_trigger
             client-payload: '{"type": "cron_trigger", "img_list": "${{ needs.check_files.outputs.children_matrix }}"}'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,11 @@ on:
         version:
           description: 'version of superbuild'
           required: true
-          default: 'v2022.x.y'
+          default: 'v2023.x.y'
+env:
+
+  REPOSITORY_NAME: ${{ github.repository }}
+  REPOSITORY_NAME_ONLY: ${{ github.event.repository.name }}
 
 jobs:
   build:
@@ -17,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get Version
         id: get_version
         run: | 
@@ -29,7 +33,10 @@ jobs:
              fi
       - name: Debug
         id: debug
-        run : echo "my version is ${{ steps.get_version.outputs.version }}"
+        run : |
+              echo "my version is ${{ steps.get_version.outputs.version }}"
+              echo "my REPOSITORY_NAME is  ${{ env.REPOSITORY_NAME }} "
+              echo "my REPOSITORY_NAME_ONLY is  ${{ env.REPOSITORY_NAME_ONLY }} "
       - name: Check Tag
         id: check_tag
         uses: mukunku/tag-exists-action@v1.2.0
@@ -52,7 +59,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name:  ${{ steps.get_version.outputs.version }}
-          release_name: docker-deployment-images  ${{ steps.get_version.outputs.version }}
+          release_name: ${{ REPOSITORY_NAME_ONLY }}  ${{ steps.get_version.outputs.version }}
           body: |
             Release  ${{ steps.get_version.outputs.version }}
           draft: false
@@ -74,6 +81,6 @@ jobs:
           GITHUB_APPS_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          repository: icub-tech-iit/docker-deployment-images
+          repository: ${{ env.REPOSITORY_NAME }}
           event-type: repository_trigger
           client-payload: '{"version": "${{ steps.get_version.outputs.version }}", "type": "repository_trigger", "img_list": "superbuild superbuild-tensorflow-cpu superbuild-tensorflow-gpu superbuild-pytorch superbuild-icubhead superbuild-icubhead-withuser superbuild-nvidia superbuild-nvidia-10.1 superbuild-gazebo blender gazebo"}'

--- a/dockerfile_images/basic/gazebo/conf_build.ini
+++ b/dockerfile_images/basic/gazebo/conf_build.ini
@@ -3,11 +3,11 @@ START_IMG=ubuntu:focal
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}_sources
 START_IMG=ubuntu:focal
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}
 
 [children]
 grasp-the-ball-gazebo

--- a/dockerfile_images/basic/gui-img/conf_build.ini
+++ b/dockerfile_images/basic/gui-img/conf_build.ini
@@ -2,6 +2,6 @@
 START_IMG=ubuntu:bionic
 
 [tag]
-icubteamcode/{{matrix.apps}}:latest
+{{matrix.apps}}:latest
 
 

--- a/dockerfile_images/basic/superbuild-gazebo/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-gazebo/conf_build.ini
@@ -5,11 +5,11 @@ release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 START_IMG=ubuntu:focal
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [demos]
 robotGazebo

--- a/dockerfile_images/basic/superbuild-google/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-google/conf_build.ini
@@ -1,13 +1,16 @@
 [sources]
-SOURCE_IMG=icubteamcode/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=icubteamcode/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+
+[tag-github]
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/basic/superbuild-google/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-google/conf_build.ini
@@ -1,15 +1,12 @@
 [sources]
-SOURCE_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
-
-[tag-github]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]

--- a/dockerfile_images/basic/superbuild-google/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-google/conf_build.ini
@@ -1,10 +1,10 @@
 [sources]
-SOURCE_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.REPOSITORY_OWNER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG={{env.REPOSITORY_OWNER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.REPOSITORY_OWNER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}

--- a/dockerfile_images/basic/superbuild-icubhead/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-icubhead/conf_build.ini
@@ -5,14 +5,11 @@ release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
-SOURCE_IMG=dockingjapo/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 START_IMG=ubuntu:focal
 
 [tag]
-dockingjapo/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
-
-[tag-github]
-${{github.repository}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/basic/superbuild-icubhead/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-icubhead/conf_build.ini
@@ -5,11 +5,14 @@ release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG=dockingjapo/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 START_IMG=ubuntu:focal
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+dockingjapo/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+
+[tag-github]
+${{github.repository}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/basic/superbuild-icubtest/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-icubtest/conf_build.ini
@@ -1,11 +1,14 @@
 [sources]
-SOURCE_IMG=icubteamcode/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+
+[tag-github]
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/basic/superbuild-icubtest/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-icubtest/conf_build.ini
@@ -1,5 +1,5 @@
 [sources]
-SOURCE_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.REPOSITORY_OWNER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}

--- a/dockerfile_images/basic/superbuild-icubtest/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-icubtest/conf_build.ini
@@ -1,13 +1,10 @@
 [sources]
-SOURCE_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [tag]
-{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
-
-[tag-github]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]

--- a/dockerfile_images/basic/superbuild-nvidia/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-nvidia/conf_build.ini
@@ -5,7 +5,7 @@ release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 
 [children]

--- a/dockerfile_images/basic/superbuild-pytorch/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-pytorch/conf_build.ini
@@ -5,11 +5,11 @@ release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 START_IMG=anibali/pytorch:1.10.2-cuda11.3-ubuntu20.04
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/basic/superbuild-ros1/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-ros1/conf_build.ini
@@ -1,12 +1,12 @@
 [sources]
-START_IMG={{env.DEFAULT_USER}}/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}_sources
+START_IMG={{env.REPOSITORY_OWNER}}/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}_sources
 $(cat DATE_TAG)
 release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
 SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG={{env.DEFAULT_USER}}/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+START_IMG={{env.REPOSITORY_OWNER}}/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}

--- a/dockerfile_images/basic/superbuild-ros1/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-ros1/conf_build.ini
@@ -1,15 +1,15 @@
 [sources]
-START_IMG=icubteamcode/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}_sources
+START_IMG={{env.DEFAULT_USER}}/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}_sources
 $(cat DATE_TAG)
 release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=icubteamcode/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.DEFAULT_USER}}/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/basic/superbuild-ros2/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-ros2/conf_build.ini
@@ -1,12 +1,12 @@
 [sources]
-START_IMG={{env.DEFAULT_USER}}/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}_sources
+START_IMG={{env.REPOSITORY_OWNER}}/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}_sources
 $(cat DATE_TAG)
 release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
 SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG={{env.DEFAULT_USER}}/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+START_IMG={{env.REPOSITORY_OWNER}}/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}

--- a/dockerfile_images/basic/superbuild-ros2/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-ros2/conf_build.ini
@@ -1,15 +1,15 @@
 [sources]
-START_IMG=icubteamcode/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}_sources
+START_IMG={{env.DEFAULT_USER}}/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}_sources
 $(cat DATE_TAG)
 release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=icubteamcode/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.DEFAULT_USER}}/superbuild-icubhead:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/basic/superbuild-tensorflow-cpu/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-tensorflow-cpu/conf_build.ini
@@ -5,11 +5,11 @@ release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 START_IMG=tensorflow/tensorflow:latest
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/basic/superbuild-tensorflow-gpu/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-tensorflow-gpu/conf_build.ini
@@ -5,11 +5,11 @@ release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 START_IMG=tensorflow/tensorflow:latest-gpu
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/basic/superbuild/conf_build.ini
+++ b/dockerfile_images/basic/superbuild/conf_build.ini
@@ -5,11 +5,11 @@ release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
-SOURCE_IMG=dockingjapo/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 START_IMG=ubuntu:focal
 
 [tag]
-dockingjapo/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [tag-github]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}

--- a/dockerfile_images/basic/superbuild/conf_build.ini
+++ b/dockerfile_images/basic/superbuild/conf_build.ini
@@ -5,7 +5,7 @@ release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
-SOURCE_IMG={{env.REPOSITORY_OWNER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 START_IMG=ubuntu:focal
 
 [tag]

--- a/dockerfile_images/basic/superbuild/conf_build.ini
+++ b/dockerfile_images/basic/superbuild/conf_build.ini
@@ -12,7 +12,7 @@ START_IMG=ubuntu:focal
 dockingjapo/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [tag-github]
-${{github.repository}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/basic/superbuild/conf_build.ini
+++ b/dockerfile_images/basic/superbuild/conf_build.ini
@@ -5,7 +5,7 @@ release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
-SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG=fakerepo/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 START_IMG=ubuntu:focal
 
 [tag]

--- a/dockerfile_images/basic/superbuild/conf_build.ini
+++ b/dockerfile_images/basic/superbuild/conf_build.ini
@@ -11,9 +11,6 @@ START_IMG=ubuntu:focal
 [tag]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
-[tag-github]
-{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
-
 [superbuild]
 
 [children]

--- a/dockerfile_images/basic/superbuild/conf_build.ini
+++ b/dockerfile_images/basic/superbuild/conf_build.ini
@@ -5,11 +5,14 @@ release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG=dockingjapo/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 START_IMG=ubuntu:focal
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+dockingjapo/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+
+[tag-github]
+${{github.repository}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/basic/superbuild/conf_build.ini
+++ b/dockerfile_images/basic/superbuild/conf_build.ini
@@ -5,7 +5,7 @@ release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
-SOURCE_IMG=fakerepo/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.REPOSITORY_OWNER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 START_IMG=ubuntu:focal
 
 [tag]

--- a/dockerfile_images/basic/superbuild/conf_build.ini
+++ b/dockerfile_images/basic/superbuild/conf_build.ini
@@ -9,7 +9,7 @@ SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{step
 START_IMG=ubuntu:focal
 
 [tag]
-valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [tag-github]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}

--- a/dockerfile_images/demos/blender/conf_build.ini
+++ b/dockerfile_images/demos/blender/conf_build.ini
@@ -5,11 +5,11 @@ release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 START_IMG=nvidia/cudagl:11.4.2-base-ubuntu20.04
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/demos/funny-things/conf_build.ini
+++ b/dockerfile_images/demos/funny-things/conf_build.ini
@@ -1,13 +1,16 @@
 [sources]
-START_IMG=icubteamcode/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=icubteamcode/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+
+[tag-github]
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/demos/funny-things/conf_build.ini
+++ b/dockerfile_images/demos/funny-things/conf_build.ini
@@ -1,15 +1,12 @@
 [sources]
-START_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
-
-[tag-github]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]

--- a/dockerfile_images/demos/funny-things/conf_build.ini
+++ b/dockerfile_images/demos/funny-things/conf_build.ini
@@ -1,10 +1,10 @@
 [sources]
-START_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.REPOSITORY_OWNER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
 SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+START_IMG={{env.REPOSITORY_OWNER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}

--- a/dockerfile_images/demos/google-vision/conf_build.ini
+++ b/dockerfile_images/demos/google-vision/conf_build.ini
@@ -1,13 +1,16 @@
 [sources]
-START_IMG=icubteamcode/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG=valegagge/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=icubteamcode/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG=valegagge/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+
+[tag-github]
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/demos/google-vision/conf_build.ini
+++ b/dockerfile_images/demos/google-vision/conf_build.ini
@@ -1,10 +1,10 @@
 [sources]
-START_IMG={{env.DEFAULT_USER}}/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.REPOSITORY_OWNER}}/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
 SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG={{env.DEFAULT_USER}}/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+START_IMG={{env.REPOSITORY_OWNER}}/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}

--- a/dockerfile_images/demos/google-vision/conf_build.ini
+++ b/dockerfile_images/demos/google-vision/conf_build.ini
@@ -1,15 +1,12 @@
 [sources]
-START_IMG=valegagge/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.DEFAULT_USER}}/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=valegagge/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.DEFAULT_USER}}/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
-
-[tag-github]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]

--- a/dockerfile_images/demos/grasp-gazebo/conf_build.ini
+++ b/dockerfile_images/demos/grasp-gazebo/conf_build.ini
@@ -3,11 +3,11 @@ START_IMG=ubuntu:focal
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}_sources
 START_IMG=ubuntu:focal
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}
 
 [demos]
 iCubGazeboGrasping

--- a/dockerfile_images/demos/grasp-the-ball-gazebo/conf_build.ini
+++ b/dockerfile_images/demos/grasp-the-ball-gazebo/conf_build.ini
@@ -1,13 +1,13 @@
 [sources]
-SOURCE_IMG=icubteamcode/gazebo:{{steps.get_version.outputs.VERSION}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/gazebo:{{steps.get_version.outputs.VERSION}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}_sources
-START_IMG=icubteamcode/gazebo:{{steps.get_version.outputs.VERSION}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}_sources
+START_IMG={{env.DEFAULT_USER}}/gazebo:{{steps.get_version.outputs.VERSION}}_sources
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}
 
 [demos]
 graspTheBallGazebo

--- a/dockerfile_images/demos/grasp-the-ball-gazebo/conf_build.ini
+++ b/dockerfile_images/demos/grasp-the-ball-gazebo/conf_build.ini
@@ -1,10 +1,10 @@
 [sources]
-SOURCE_IMG={{env.DEFAULT_USER}}/gazebo:{{steps.get_version.outputs.VERSION}}_sources
+SOURCE_IMG={{env.REPOSITORY_OWNER}}/gazebo:{{steps.get_version.outputs.VERSION}}_sources
 $(cat DATE_TAG)
 
 [binaries]
 SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}_sources
-START_IMG={{env.DEFAULT_USER}}/gazebo:{{steps.get_version.outputs.VERSION}}_sources
+START_IMG={{env.REPOSITORY_OWNER}}/gazebo:{{steps.get_version.outputs.VERSION}}_sources
 
 [tag]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}

--- a/dockerfile_images/demos/grasp-the-ball/conf_build.ini
+++ b/dockerfile_images/demos/grasp-the-ball/conf_build.ini
@@ -1,13 +1,16 @@
 [sources]
-SOURCE_IMG=icubteamcode/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=icubteamcode/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+
+[tag-github]
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/demos/grasp-the-ball/conf_build.ini
+++ b/dockerfile_images/demos/grasp-the-ball/conf_build.ini
@@ -1,15 +1,12 @@
 [sources]
-SOURCE_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
-
-[tag-github]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]

--- a/dockerfile_images/demos/grasp-the-ball/conf_build.ini
+++ b/dockerfile_images/demos/grasp-the-ball/conf_build.ini
@@ -1,10 +1,10 @@
 [sources]
-SOURCE_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.REPOSITORY_OWNER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
 SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+START_IMG={{env.REPOSITORY_OWNER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}

--- a/dockerfile_images/demos/human-sensing/conf_build.ini
+++ b/dockerfile_images/demos/human-sensing/conf_build.ini
@@ -1,10 +1,10 @@
 [sources]
-SOURCE_IMG={{env.DEFAULT_USER}}/superbuild-nvidia:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.REPOSITORY_OWNER}}/superbuild-nvidia:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
 SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG={{env.DEFAULT_USER}}/superbuild-nvidia:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.REPOSITORY_OWNER}}/superbuild-nvidia:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 
 [tag]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}

--- a/dockerfile_images/demos/human-sensing/conf_build.ini
+++ b/dockerfile_images/demos/human-sensing/conf_build.ini
@@ -1,13 +1,13 @@
 [sources]
-SOURCE_IMG=icubteamcode/superbuild-nvidia:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/superbuild-nvidia:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=icubteamcode/superbuild-nvidia:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.DEFAULT_USER}}/superbuild-nvidia:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/demos/open-face/conf_build.ini
+++ b/dockerfile_images/demos/open-face/conf_build.ini
@@ -1,13 +1,16 @@
 [sources]
-SOURCE_IMG=icubteamcode/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=icubteamcode/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+
+[tag-github]
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/demos/open-face/conf_build.ini
+++ b/dockerfile_images/demos/open-face/conf_build.ini
@@ -1,15 +1,12 @@
 [sources]
-SOURCE_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
-
-[tag-github]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]

--- a/dockerfile_images/demos/open-face/conf_build.ini
+++ b/dockerfile_images/demos/open-face/conf_build.ini
@@ -1,10 +1,10 @@
 [sources]
-SOURCE_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.REPOSITORY_OWNER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG={{env.REPOSITORY_OWNER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.REPOSITORY_OWNER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}

--- a/dockerfile_images/demos/speech/conf_build.ini
+++ b/dockerfile_images/demos/speech/conf_build.ini
@@ -1,10 +1,10 @@
 [sources]
-SOURCE_IMG={{env.DEFAULT_USER}}/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.REPOSITORY_OWNER}}/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
 SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG={{env.DEFAULT_USER}}/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+START_IMG={{env.REPOSITORY_OWNER}}/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}

--- a/dockerfile_images/demos/speech/conf_build.ini
+++ b/dockerfile_images/demos/speech/conf_build.ini
@@ -1,15 +1,12 @@
 [sources]
-SOURCE_IMG=valegagge/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=valegagge/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.DEFAULT_USER}}/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
-
-[tag-github]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]

--- a/dockerfile_images/demos/speech/conf_build.ini
+++ b/dockerfile_images/demos/speech/conf_build.ini
@@ -1,13 +1,16 @@
 [sources]
-SOURCE_IMG=icubteamcode/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG=valegagge/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=icubteamcode/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG=valegagge/superbuild-google:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+
+[tag-github]
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/demos/supervise-calib/conf_build.ini
+++ b/dockerfile_images/demos/supervise-calib/conf_build.ini
@@ -1,13 +1,16 @@
 [sources]
-SOURCE_IMG=icubteamcode/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=icubteamcode/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-icubteamcode/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
+
+[tag-github]
+{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]
 

--- a/dockerfile_images/demos/supervise-calib/conf_build.ini
+++ b/dockerfile_images/demos/supervise-calib/conf_build.ini
@@ -1,15 +1,12 @@
 [sources]
-SOURCE_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG=valegagge/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG=valegagge/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
-{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
-
-[tag-github]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}
 
 [superbuild]

--- a/dockerfile_images/demos/supervise-calib/conf_build.ini
+++ b/dockerfile_images/demos/supervise-calib/conf_build.ini
@@ -1,10 +1,10 @@
 [sources]
-SOURCE_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+SOURCE_IMG={{env.REPOSITORY_OWNER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
 $(cat DATE_TAG)
 
 [binaries]
-SOURCE_IMG={{env.DEFAULT_USER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-START_IMG={{env.DEFAULT_USER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
+SOURCE_IMG={{env.REPOSITORY_OWNER}}/{{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
+START_IMG={{env.REPOSITORY_OWNER}}/superbuild:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_binaries
 
 [tag]
 {{matrix.apps}}:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}


### PR DESCRIPTION
With this PR new steps are added to the Wokflow file.
Specifically, we have that:
- specific `tag` steps, for both `docker-hub` image tag and `ghcr`, are defined, so that in ghcr we can have new tags for the images, which follow a chosen standard, instead in docker-hub we can continue to use the old naming convention
- `docker push` step specific for adding to ghcr the images has been added. 
- doing so we have also decided to make the workflow file and the `conf_build.ini` files of the images more general by using `github context` properties and environmental variables
- all of this has been done with the idea of moving, in the future, the docker images to github container registry instead of keeping them only on docker-hub