### PR TITLE
Add ARG ROS_IMG=humble to Dockerfile for superbuild-ros2

### DIFF
--- a/dockerfile_images/basic/superbuild-ros2/Dockerfile
+++ b/dockerfile_images/basic/superbuild-ros2/Dockerfile
@@ -7,6 +7,7 @@ ARG METADATA_FILE="/usr/local/bin/setup_metadata.sh"
 
 # Definitions
 ARG ROS_IMG=ros:humble-ros-base-jammy
+ARG ROS_DISTRO="humble"
 # TODO Now it is working only with icub-main devel START_IMG IGNORED
 #ARG SUPERBUILD_IMG=icubteamcode/superbuild-icubhead:master-unstable_sources
 # ARG SUPERBUILD_IMG=test-superbuild-icubhead:jammy


### PR DESCRIPTION
Add ARG with specific ros2 distro.
Tested as here 

![image](https://github.com/icub-tech-iit/docker-deployment-images/assets/77933235/be1f06dd-4a07-45ba-ab3e-a03f21a943ea)

where the test image used has been built as here:

![image](https://github.com/icub-tech-iit/docker-deployment-images/assets/77933235/2e27a9b4-8d54-4cfe-8bbd-d7b62a7f004d)
