### PR TITLE
Update superbuild-ros2 Dockerfiles for source and binary images

### DIFF
--- a/dockerfile_images/basic/superbuild-ros1/Dockerfile
+++ b/dockerfile_images/basic/superbuild-ros1/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=superbuild_builder /usr /usr
 COPY --from=superbuild_builder /etc /etc
 
 RUN apt update && apt install -y ros-noetic-rqt ros-noetic-rqt-common-plugins wget
-RUN echo 'source "/opt/ros/$ROS_DISTRO/setup.bash"' >> /usr/local/bin/setup_robotology_tdd.sh
+RUN echo 'source "/opt/ros/noetic/setup.bash"' >> /usr/local/bin/setup_robotology_tdd.sh
 
 WORKDIR /root
 RUN wget https://github.com/icub-tech-iit/appsAway/files/8919271/FT_setup.zip

--- a/dockerfile_images/basic/superbuild-ros2/Dockerfile
+++ b/dockerfile_images/basic/superbuild-ros2/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=superbuild_builder /usr /usr
 COPY --from=superbuild_builder /etc /etc
 
 RUN apt update && apt install -y \
-    ros-humble-rqt ros-humble-rqt-common-plugins ros-humble-test-msgs \
+    ros-humble-rqt ros-humble-rqt-common-plugins ros-humble-test-msgs ros-humble-desktop ros-dev-tools \
     wget \
     unzip
 RUN echo 'source /opt/ros/humble/setup.bash' >> /usr/local/bin/setup_robotology_tdd.sh

--- a/dockerfile_images/basic/superbuild-ros2/Dockerfile
+++ b/dockerfile_images/basic/superbuild-ros2/Dockerfile
@@ -7,7 +7,7 @@ ARG METADATA_FILE="/usr/local/bin/setup_metadata.sh"
 
 # Definitions
 ARG ROS_IMG=ros:humble-ros-base-jammy
-ARG ROS_DISTRO="humble"
+ARG ROS_DISTRO=humble
 # TODO Now it is working only with icub-main devel START_IMG IGNORED
 #ARG SUPERBUILD_IMG=icubteamcode/superbuild-icubhead:master-unstable_sources
 # ARG SUPERBUILD_IMG=test-superbuild-icubhead:jammy
@@ -30,7 +30,7 @@ RUN apt update && apt install -y \
     ros-humble-rqt ros-humble-rqt-common-plugins ros-humble-test-msgs \
     wget \
     unzip
-RUN echo 'source "/opt/ros/$ROS_DISTRO/setup.bash"' >> /usr/local/bin/setup_robotology_tdd.sh
+RUN echo 'source /opt/ros/humble/setup.bash' >> /usr/local/bin/setup_robotology_tdd.sh
 
 WORKDIR /root
 RUN wget https://github.com/icub-tech-iit/appsAway/files/8919271/FT_setup.zip

--- a/dockerfile_images/basic/superbuild-ros2/Dockerfile4Production
+++ b/dockerfile_images/basic/superbuild-ros2/Dockerfile4Production
@@ -10,6 +10,7 @@ LABEL maintainer="jacopo.losi@iit.it, valentina.gaggero@iit.it"
 
 COPY --from=builder /usr /usr
 COPY --from=builder /etc /etc
+COPY --from=builder /opt /opt
 
 FROM scratch
 

--- a/dockerfile_images/basic/superbuild-ros2/README.md
+++ b/dockerfile_images/basic/superbuild-ros2/README.md
@@ -1,0 +1,3 @@
+# Dokcer image based on superbuiild and ros2-humble distro
+
+This image is based on ` robotology superbuild` built over ubuntu 22.04 jammy-jellyfish and on the ros2 distro `humble`, specifically it exploits the ros imge `ros:humble-ros-base-jammy`.


### PR DESCRIPTION
Introduce some fix to the ROS_DISTRO ARG and to the line that copies the command ` 'source /opt/ros/humble/setup.bash'` to the entrypoint bash file.
Now it should work correctly.
Tested not only sources but also binary image built locally.
Waiting for the merge to master for final check using images compiled online.

cc: @valegagge 