### PR TITLE
Update stages dockerfile for icubhead-withuser and robometry children

### DIFF
--- a/dockerfile_images/basic/superbuild-icubhead-robometry/Dockerfile
+++ b/dockerfile_images/basic/superbuild-icubhead-robometry/Dockerfile
@@ -1,16 +1,24 @@
 #here add all stuff necessary to run icub-tests
 #start from image passed by argument during build process. Usually it is icubteamcode/superbuild:master-unstable_source
 ARG SOURCE_IMG="none"
-ARG PROJECTS_DIR="/home/icub/projects"
-ARG INSTALL_DIR="/home/icub/install_dir"
-ARG release="none"
-ARG sbtag="none"
+
+ARG HOME_DIR=/home/icub
+ARG PROJECTS_DIR=${HOME_DIR}/projects
+ARG INSTALL_DIR=${HOME_DIR}/install_dir
+ARG release="master"
+ARG sbtag="Stable"
+ARG metadata="data"
 ARG METADATA_FILE=${INSTALL_DIR}/bin/setup_metadata.sh
+ARG ROBOTOLOGY_INITIALIZATION_FILE=/usr/local/bin/setup_robotology_tdd.sh
+
+# Define default user
+ARG USERNAME=icub
 
 FROM $SOURCE_IMG as superbuild_builder
 
 LABEL maintainer="valentina.gaggero@iit.it, jacopo.losi@iit.it"
 
+ARG HOME_DIR
 ARG PROJECTS_DIR
 ARG CMAKE_GENERATOR
 ARG BUILD_TYPE
@@ -19,8 +27,17 @@ ARG INSTALL_DIR
 ARG release
 ARG sbtag
 ARG METADATA_FILE
+ARG ROBOTOLOGY_INITIALIZATION_FILE
+ARG USERNAME
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+USER $USERNAME
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY setup.sh ${ROBOTOLOGY_INITIALIZATION_FILE}
+RUN sudo chown -R icub: /usr/local/bin/entrypoint.sh
+RUN sudo chown -R icub: /usr/local/bin/setup_robotology_tdd.sh
 
 # Some other definitions
 ARG CMAKE_GENERATOR="Unix Makefiles"
@@ -58,6 +75,10 @@ ARG release
 ARG sbtag
 ARG METADATA_FILE
 ARG metadata
+ARG ROBOTOLOGY_INITIALIZATION_FILE
+ARG USERNAME
+
+USER $USERNAME
 
 COPY --from=superbuild_builder / /
 
@@ -68,12 +89,11 @@ ENV CMAKE_PREFIX_PATH=${INSTALL_DIR}
 ENV QT_X11_NO_MITSHM=1 
 ENV YARP_COLORED_OUTPUT=1 
 
-RUN echo "File metadata = ${METADATA_FILE}" &&\
-    echo 'echo 'This images has release=$release and had been built with superbuild_tag=$sbtag. Metadata=$metadata ' '  >> $METADATA_FILE
+RUN echo 'echo 'This images has release=$release and is built with superbuild_tag=$sbtag. Metadata=$metadata ' '  >> $METADATA_FILE
 
+RUN echo "source ${INSTALL_DIR}/share/robotology-superbuild/setup.sh" >>  $ROBOTOLOGY_INITIALIZATION_FILE
+RUN echo "source ${METADATA_FILE}" >> $ROBOTOLOGY_INITIALIZATION_FILE
 
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
 
- 
 CMD ["bash"]

--- a/dockerfile_images/basic/superbuild-icubhead-robometry/entrypoint.sh
+++ b/dockerfile_images/basic/superbuild-icubhead-robometry/entrypoint.sh
@@ -8,8 +8,9 @@ fi
 
 source setup_robotology_tdd.sh
 
-echo "[ -r /usr/share/bash-completion/bash_completion   ] && . /usr/share/bash-completion/bash_completion" >> /root/.bashrc
-echo "[ -r /usr/local/bin/setup_robotology_tdd.sh   ] && . /usr/local/bin/setup_robotology_tdd.sh" >> /root/.bashrc
+echo "[ -r /usr/share/bash-completion/bash_completion   ] && . /usr/share/bash-completion/bash_completion" >> /home/icub/.bashrc
+echo "[ -r /usr/local/bin/setup_robotology_tdd.sh   ] && . /usr/local/bin/setup_robotology_tdd.sh" >> /home/icub/.bashrc
 
+# If a CMD is passed, execute it
 exec "$@"
 

--- a/dockerfile_images/basic/superbuild-icubhead-withuser/Dockerfile
+++ b/dockerfile_images/basic/superbuild-icubhead-withuser/Dockerfile
@@ -1,16 +1,33 @@
 #start from image passed by argument during build process. Usually it is an ubuntu image plus mesa library.
 ARG START_IMG="none"
 
-FROM $START_IMG
+ARG HOME_DIR=/home/icub
+ARG INSTALL_DIR=${HOME_DIR}/install_dir
+ARG PROJECTS_DIR=${HOME_DIR}/projects
+ARG release="master"
+ARG sbtag="Stable"
+ARG metadata="data"
+ARG METADATA_FILE=${INSTALL_DIR}/bin/setup_metadata.sh
+ARG ROBOTOLOGY_INITIALIZATION_FILE=/usr/local/bin/setup_robotology_tdd.sh
+ARG USERNAME=icub
+
+FROM $START_IMG as builder
 
 LABEL maintainer="valentina.gaggero@iit.it, jacopo.losi@iit.it"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG USERNAME=icub
+ARG INSTALL_DIR
+ARG PROJECTS_DIR
+ARG release
+ARG sbtag
+ARG METADATA_FILE
+ARG ROBOTOLOGY_INITIALIZATION_FILE
+
+# Define UID and GID
+ARG USERNAME
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-
 
 RUN apt-get update \
     && apt-get install -y sudo \
@@ -22,6 +39,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
  
 
+# From here on all commands will be executed as $USERNAME user until FROM declaration
 USER $USERNAME
 
 RUN sudo mkdir /etc/bash_completion.d/ &&\
@@ -33,29 +51,15 @@ RUN sudo mkdir /etc/bash_completion.d/ &&\
         vim \
         apt-utils
 
-
-#Some definitions
-ARG CMAKE_GENERATOR="Unix Makefiles"
-ARG BUILD_TYPE=Release
-ARG CMAKE_EXTRA_OPTIONS=-j2
-ARG INSTALL_DIR=/home/icub/install_dir
-ARG release="master"
-ARG sbtag="Stable"
-ARG METADATA_FILE=/home/icub/install_dir/bin/setup_metadata.sh
-
-
-# Setup entrypoint
-ARG ROBOTOLOGY_INITIALIZATION_FILE=/usr/local/bin/setup_robotology_tdd.sh
-
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY setup.sh ${ROBOTOLOGY_INITIALIZATION_FILE}
 RUN sudo chown -R icub: /usr/local/bin/entrypoint.sh
 RUN sudo chown -R icub: /usr/local/bin/setup_robotology_tdd.sh
 
-ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
-
-
-ARG PROJECTS_DIR=/home/icub/projects
+#Some definitions
+ARG CMAKE_GENERATOR="Unix Makefiles"
+ARG BUILD_TYPE=Release
+ARG CMAKE_EXTRA_OPTIONS=-j2
 
 #ENV DEBIAN_FRONTEND=noninteractive is not sufficient
 RUN echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections &&\
@@ -79,16 +83,30 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-sel
         -DENABLE_yarpmod_grabber:BOOL=ON \
        &&\
     #Build all the projects &&\
-    cmake --build . --target update-all -- -j4 &&\
+    cmake --build . --target update-all -- ${CMAKE_EXTRA_OPTIONS} &&\
     cmake --build . -- ${CMAKE_EXTRA_OPTIONS}
 
+FROM scratch 
 
- RUN echo "source ${INSTALL_DIR}/share/robotology-superbuild/setup.sh" >>  $ROBOTOLOGY_INITIALIZATION_FILE
- RUN echo "source ${METADATA_FILE}" >> $ROBOTOLOGY_INITIALIZATION_FILE
+ARG PROJECTS_DIR
+ARG CMAKE_GENERATOR="Unix Makefiles"
+ARG BUILD_TYPE=Release
+ARG CMAKE_EXTRA_OPTIONS=-j2
+ARG INSTALL_DIR
+ARG release
+ARG sbtag
+ARG METADATA_FILE
+ARG ROBOTOLOGY_INITIALIZATION_FILE
+ARG metadata
+ARG USERNAME
+
+USER $USERNAME
+
+COPY --from=builder / /
 
 # # The bashrc is read only when opening an interactive shell. Let other projects find packages contained
 # # in the superbuild.
- ENV CMAKE_PREFIX_PATH=${INSTALL_DIR}
+ENV CMAKE_PREFIX_PATH=${INSTALL_DIR}
 
 #add checkRobotInterface
 RUN cd ${PROJECTS_DIR} &&\
@@ -100,8 +118,7 @@ RUN cd ${PROJECTS_DIR} &&\
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
         &&\
     cmake --build . -- ${CMAKE_EXTRA_OPTIONS} && \
-    cp ./checkRobotInterface /home/icub/install_dir/bin
-
+    cp ./checkRobotInterface ${INSTALL_DIR}/bin
 
 
 #The EXPOSE instruction does not actually publish the port.
@@ -113,15 +130,12 @@ EXPOSE 10000/tcp 10000/udp
 ENV QT_X11_NO_MITSHM 1
 ENV YARP_COLORED_OUTPUT 1
 
+RUN echo 'echo 'This images has release=$release and is built with superbuild_tag=$sbtag. Metadata=$metadata ' '  >> $METADATA_FILE
 
+RUN echo "source ${INSTALL_DIR}/share/robotology-superbuild/setup.sh" >>  $ROBOTOLOGY_INITIALIZATION_FILE
+RUN echo "source ${METADATA_FILE}" >> $ROBOTOLOGY_INITIALIZATION_FILE
 
-ARG metadata="none"
-
-ENV img_metadata=${metadata}
-RUN echo "File metadata = ${METADATA_FILE}"
-RUN echo 'export img_metadata=${metadata}'  >> $METADATA_FILE
-RUN echo 'echo 'This images has release=$release and had been building with superbuild_tag=$sbtag. Metadata=$metadata ' '  >> $METADATA_FILE
-
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
 
 CMD ["bash"]
 

--- a/dockerfile_images/basic/superbuild-icubhead-withuser/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-icubhead-withuser/conf_build.ini
@@ -1,6 +1,6 @@
 [sources]
 START_IMG=ubuntu:jammy
-$(cat DATE_TAG)
+metadata=$(cat DATE_TAG)
 release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 


### PR DESCRIPTION
This PR has the following changes:

We realized that the child image of superbuild-icubhead-withuser, i.e. superbuild-icubhead-robometry,  was not using the icubuser but the root user instead.
Therefore, I made some changes on both the parent and the child image thus to update the stages of the compilation and making possible to have the icub user on the child image as well. 
In this way it is possible to export file from the container locally, which is the main aim of the `withuser` images. This can be achieved only using the container with the ownership of a local (not root) user.

cc: @valegagge 