### PR TITLE
Update and fix children images

### DIFF
--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -21,7 +21,7 @@ jobs:
     debug:
       runs-on: [ubuntu-latest]
       steps: 
-      - id: get_data
+      - id: get_date
         run: |
           echo "$(date +'%d/%m/%Y_%H:%M:%S')" > DATE_HOUR_
           echo "metadata=$(cat DATE_HOUR_)" > DATE_HOUR_TAG

--- a/dockerfile_images/basic/superbuild-icubhead-robometry/Dockerfile
+++ b/dockerfile_images/basic/superbuild-icubhead-robometry/Dockerfile
@@ -39,6 +39,9 @@ COPY setup.sh ${ROBOTOLOGY_INITIALIZATION_FILE}
 RUN sudo chown -R icub: /usr/local/bin/entrypoint.sh
 RUN sudo chown -R icub: /usr/local/bin/setup_robotology_tdd.sh
 
+RUN git config --global user.email "icub@icub.it" &&\
+    git config --global user.name "icub"
+
 # Some other definitions
 ARG CMAKE_GENERATOR="Unix Makefiles"
 ARG BUILD_TYPE=Release
@@ -50,12 +53,11 @@ RUN cd ${PROJECTS_DIR}/robotology-superbuild &&\
     -G "$CMAKE_GENERATOR" \
         -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-        -DNON_INTERACTIVE_BUILD:BOOL=ON \
+        -DNON_INTERACTIVE_BUILD:BOOL=OFF \
         -DROBOTOLOGY_ENABLE_CORE:BOOL=ON \
         -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=ON \
         # for enabling robometry
         -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=ON \ 
-        -DYCM_USE_DEPRECATED:BOOL=OFF \
         -DROBOTOLOGY_USES_GAZEBO=OFF \
         -DROBOTOLOGY_PROJECT_TAGS=${sbtag} \
         -DYCM_USE_CMAKE_PROPOSED=ON \

--- a/dockerfile_images/basic/superbuild-icubhead/Dockerfile
+++ b/dockerfile_images/basic/superbuild-icubhead/Dockerfile
@@ -4,9 +4,10 @@ ARG ROBOTOLOGY_INITIALIZATION_FILE=/usr/local/bin/setup_robotology_tdd.sh
 ARG METADATA_FILE=/usr/local/bin/setup_metadata.sh
 ARG PROJECTS_DIR=/projects
 ARG INSTALL_DIR=${PROJECTS_DIR}/robotology-superbuild/build/install
-ARG release="none"
-ARG sbtag="none"
-ARG metadata="none"
+# Default tags
+ARG release="master"
+ARG sbtag="Stable"
+ARG metadata="data"
 
 FROM $START_IMG AS builder
 
@@ -62,8 +63,7 @@ RUN mkdir ${PROJECTS_DIR} && cd ${PROJECTS_DIR} &&\
 
 # Executing commands in chain makes compilation faster
 # other then calling the command RUN everytime
-RUN echo "source ${INSTALL_DIR}/share/robotology-superbuild/setup.sh" >> $ROBOTOLOGY_INITIALIZATION_FILE &&\
-    echo "source ${METADATA_FILE}" >> $ROBOTOLOGY_INITIALIZATION_FILE
+RUN echo "source ${INSTALL_DIR}/share/robotology-superbuild/setup.sh" >> $ROBOTOLOGY_INITIALIZATION_FILE
 
 # Stage 2: secondstage stage
 FROM $START_IMG AS secondstage
@@ -89,18 +89,20 @@ COPY --from=secondstage / /
 EXPOSE 10000/tcp 10000/udp
 
 # Some QT-Apps don't show controls without this
-ENV QT_X11_NO_MITSHM 1
-ENV YARP_COLORED_OUTPUT 1
+ENV QT_X11_NO_MITSHM=1
+ENV YARP_COLORED_OUTPUT=1
 
+ARG ROBOTOLOGY_INITIALIZATION_FILE
 ARG METADATA_FILE
 ARG release
 ARG sbtag
 ARG metadata
 
-ENV img_metadata=${metadata}
 
-RUN echo 'export img_metadata=${metadata}'  > $METADATA_FILE &&\
-    echo 'echo 'This images has release=$release and had been building with superbuild_tag=$sbtag. Metadata=$metadata ' '  >> $METADATA_FILE
+
+RUN echo 'echo 'This images has release=$release and is built with superbuild_tag=$sbtag. Metadata=$metadata ' '  >> $METADATA_FILE
+
+RUN echo "source ${METADATA_FILE}" >> $ROBOTOLOGY_INITIALIZATION_FILE
 
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
 

--- a/dockerfile_images/basic/superbuild-icubtest/Dockerfile
+++ b/dockerfile_images/basic/superbuild-icubtest/Dockerfile
@@ -4,9 +4,11 @@ ARG SOURCE_IMG="none"
 ARG METADATA_FILE=/usr/local/bin/setup_metadata.sh
 ARG PROJECTS_DIR=/projects
 ARG INSTALL_DIR=${PROJECTS_DIR}/robotology-superbuild/build/install
-ARG release="none"
-ARG sbtag="none"
-ARG metadata="none"
+ARG ROBOTOLOGY_INITIALIZATION_FILE=/usr/local/bin/setup_robotology_tdd.sh
+# Default tags
+ARG release="master"  
+ARG sbtag="Stable"
+ARG metadata="data"
 
 # Stage 1: build stage
 FROM $SOURCE_IMG AS builder
@@ -16,25 +18,19 @@ LABEL maintainer="valentina.gaggero@iit.it, jacopo.losi@iit.it"
 ARG METADATA_FILE
 ARG INSTALL_DIR
 ARG PROJECTS_DIR
+ARG ROBOTOLOGY_INITIALIZATION_FILE
 ARG release
 ARG sbtag
 ARG metadata
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY setup.sh ${ROBOTOLOGY_INITIALIZATION_FILE}
 
 ARG CMAKE_GENERATOR="Unix Makefiles"
 ARG BUILD_TYPE=Release
 ARG CMAKE_EXTRA_OPTIONS=-j4
 
 ENV DEBIAN_FRONTEND=noninteractive
-
-#The EXPOSE instruction does not actually publish the port.
-#It functions as a type of documentation between the person who builds the image and the person who runs the container, about which ports are intended to be published.
-#To actually publish the port when running the container, use the -p flag on docker run to publish and map one or more ports, or the -P flag to publish all exposed ports and map them to high-order ports.
-EXPOSE 10000/tcp 10000/udp 
-#is necessary to expose port??
-
-# Some QT-Apps don't show controls without this
-ENV QT_X11_NO_MITSHM 1
-ENV YARP_COLORED_OUTPUT=1
 
 # Dependencies for gnuplot
 RUN apt update && \
@@ -58,18 +54,26 @@ RUN cd ${PROJECTS_DIR}/robotology-superbuild &&\
         # Build all the projects
         cmake --build . -- ${CMAKE_EXTRA_OPTIONS}
 
+RUN echo "source ${INSTALL_DIR}/share/robotology-superbuild/setup.sh" >>  $ROBOTOLOGY_INITIALIZATION_FILE
 # Stage 2: scratch stage
 # This should theoretically help reducing the size of the final image
 FROM scratch
-COPY --from=secondstage / /
+COPY --from=builder / /
 
-ARG metadata
+#The EXPOSE instruction does not actually publish the port.
+#It functions as a type of documentation between the person who builds the image and the person who runs the container, about which ports are intended to be published.
+#To actually publish the port when running the container, use the -p flag on docker run to publish and map one or more ports, or the -P flag to publish all exposed ports and map them to high-order ports.
+EXPOSE 10000/tcp 10000/udp 
+#is necessary to expose port??
+
+# Some QT-Apps don't show controls without this
+ENV QT_X11_NO_MITSHM=1
+ENV YARP_COLORED_OUTPUT=1
+
 ARG METADATA_FILE
+ARG ROBOTOLOGY_INITIALIZATION_FILE
 
-ENV img_metadata=${metadata}
-
-RUN echo 'export img_metadata=${metadata}'  > $METADATA_FILE
-RUN echo 'echo 'This image was built on $metadata ' '  >> $METADATA_FILE
+RUN echo "source ${METADATA_FILE}" >> $ROBOTOLOGY_INITIALIZATION_FILE
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/dockerfile_images/basic/superbuild-ros2/Dockerfile
+++ b/dockerfile_images/basic/superbuild-ros2/Dockerfile
@@ -1,16 +1,16 @@
-# TODO: remove or correct
 #start from image passed by argument during build process. Usually it is an ubuntu image plus mesa library.
 ARG START_IMG="none"
-ARG METADATA_FILE="/usr/local/bin/setup_metadata.sh"
-
-#FROM $START_IMG as builder
+ARG METADATA_FILE=/usr/local/bin/setup_metadata.sh
+ARG ROBOTOLOGY_INITIALIZATION_FILE=/usr/local/bin/setup_robotology_tdd.sh
+ARG release="master"
+ARG sbtag="Stable"
+ARG metadata="data"
 
 # Definitions
 ARG ROS_IMG=ros:humble-ros-base-jammy
 ARG ROS_DISTRO=humble
-# TODO Now it is working only with icub-main devel START_IMG IGNORED
-#ARG SUPERBUILD_IMG=icubteamcode/superbuild-icubhead:master-unstable_sources
 ARG PROJECTS_DIR=/projects
+ARG INSTALL_DIR=${PROJECTS_DIR}/robotology-superbuild/build/install
 
 FROM $START_IMG AS superbuild_builder
 FROM $ROS_IMG AS ros_builder
@@ -21,6 +21,8 @@ LABEL maintainer="valentina.gaggero@iit.it, jacopo.losi@iit.it"
 
 ARG ROS_DISTRO
 ARG PROJECTS_DIR
+ARG INSTALL_DIR
+ARG ROBOTOLOGY_INITIALIZATION_FILE
 
 COPY --from=superbuild_builder ${PROJECTS_DIR} ${PROJECTS_DIR}
 COPY --from=superbuild_builder /usr /usr
@@ -31,56 +33,56 @@ RUN apt update && apt install -y \
     ros-humble-rmw-cyclonedds-cpp ros-humble-ament-cmake-clang-format ros-humble-hardware-interface ros-humble-controller-manager ros-humble-ros2-control \
     wget \
     unzip
-RUN echo 'source /opt/ros/humble/setup.bash' >> /usr/local/bin/setup_robotology_tdd.sh
+RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.bash' >> ${ROBOTOLOGY_INITIALIZATION_FILE}
 
 
 FROM $ROS_IMG AS secondstage
 
 ARG ROS_DISTRO
 ARG PROJECTS_DIR
+ARG INSTALL_DIR
+ARG METADATA_FILE
+ARG ROBOTOLOGY_INITIALIZATION_FILE
+ARG release
+ARG sbtag
+ARG metadata
 
 COPY --from=ros_builder / /
 
-WORKDIR /root
-RUN wget https://github.com/icub-tech-iit/appsAway/files/8919271/FT_setup.zip
-RUN unzip FT_setup
+ARG CMAKE_GENERATOR="Unix Makefiles"
+ARG BUILD_TYPE=Release
+ARG CMAKE_EXTRA_OPTIONS=-j4
+ARG CMAKE_PREFIX_PATH=/usr/local
 
-WORKDIR /root
-RUN wget https://github.com/icub-tech-iit/appsAway/files/9112222/FT_setup_can.zip
-RUN unzip FT_setup_can
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY setup.sh ${ROBOTOLOGY_INITIALIZATION_FILE}
 
-# TODO to be removed once it will merged on upstream branch
-RUN cd ${PROJECTS_DIR} && git clone https://github.com/robotology/yarp &&\
-    cd yarp &&\
-    git checkout master &&\
-    mkdir build && cd build &&\
-    cmake .. &&\
-    make install -j5
-
-# TODO to be removed once it will merged on upstream branch
-RUN cd ${PROJECTS_DIR} && git clone -b master https://github.com/robotology/icub-main &&\
-    cd icub-main &&\
-    mkdir build && cd build &&\
-    cmake .. \
-        -DENABLE_icubmod_canBusFtSensor:BOOL=ON \
-        -DENABLE_icubmod_canBusAnalogSensor:BOOL=ON \
-        -DENABLE_icubmod_embObjFTsensor:BOOL=ON \
-        &&\
-    make install -j5
-
-
-RUN bash -c "source /opt/ros/$ROS_DISTRO/setup.bash &&\
+RUN bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash &&\
     echo $AMENT_PREFIX_PATH &&\
-    echo $AMENT_CURRENT_PREFIX &&\
-    cd ${PROJECTS_DIR} &&\
-    git clone -b master https://github.com/robotology/yarp-devices-ros2.git &&\
-    cd yarp-devices-ros2/ros2_interfaces_ws &&\
-    colcon build &&\
-    source install/setup.bash &&\
-    cd .. &&\
-    mkdir build && cd build &&\
-    cmake .. &&\
-    make install -j4"
+    echo $AMENT_CURRENT_PREFIX"
+    
+RUN cd ${PROJECTS_DIR}/robotology-superbuild &&\
+    cd build &&\
+    cmake .. \
+    -G "$CMAKE_GENERATOR" \
+        -DCMAKE_INSTALL_PREFIX=${CMAKE_PREFIX_PATH} \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DNON_INTERACTIVE_BUILD:BOOL=ON \
+        -DROBOTOLOGY_ENABLE_CORE:BOOL=ON \
+        -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=ON \
+        # for enabling yarp-devices-ros2
+        -DROBOTOLOGY_ENABLE_ROS2:BOOL=ON \
+        -DROBOTOLOGY_PROJECT_TAGS=${sbtag} \
+        &&\
+        # Build all the projects
+        cmake --build . -- ${CMAKE_EXTRA_OPTIONS}
+
+ENV QT_X11_NO_MITSHM=1 
+ENV YARP_COLORED_OUTPUT=1
+
+RUN echo "source ${INSTALL_DIR}/share/robotology-superbuild/setup.sh" >>  $ROBOTOLOGY_INITIALIZATION_FILE
+RUN echo "source ${METADATA_FILE}" >> $ROBOTOLOGY_INITIALIZATION_FILE
+RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >>  $ROBOTOLOGY_INITIALIZATION_FILE
 
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
 CMD ["bash"]

--- a/dockerfile_images/basic/superbuild/Dockerfile
+++ b/dockerfile_images/basic/superbuild/Dockerfile
@@ -1,12 +1,12 @@
 #start from image passed by argument during build process. Usually it is an ubuntu image plus mesa library.
 ARG START_IMG="none"
 
-ARG METADATA_FILE="/usr/local/bin/setup_metadata.sh"
+ARG METADATA_FILE=/usr/local/bin/setup_metadata.sh
 ARG PROJECTS_DIR=/projects
 ARG INSTALL_DIR=${PROJECTS_DIR}/robotology-superbuild/build/install
 ARG release="master"
 ARG sbtag="Stable"
-ARG METADATA_FILE=${INSTALL_DIR}/bin/setup_metadata.sh
+ARG metadata="data"
 ARG ROBOTOLOGY_INITIALIZATION_FILE=/usr/local/bin/setup_robotology_tdd.sh
 
 FROM $START_IMG AS builder
@@ -80,25 +80,21 @@ RUN rm -rf ${PROJECTS_DIR}/robotology-superbuild/build/src &&\
 FROM $START_IMG  AS secondstage
 
 # Setup entrypoint
-ARG ROBOTOLOGY_INITIALIZATION_FILE
-
 ARG PROJECTS_DIR
-ARG METADATA_FILE
-ARG release
-ARG sbtag
-ARG metadata
+
 
 COPY --from=builder ${PROJECTS_DIR} ${PROJECTS_DIR}
 COPY --from=builder /usr /usr
 COPY --from=builder /etc /etc
 
-RUN echo 'export img_metadata=${metadata}'  > ${METADATA_FILE}  &&\
-    echo 'echo 'This images has release=$release and had been building with superbuild_tag=$sbtag. Metadata=$metadata' '  >> ${METADATA_FILE} &&\
-    echo "source ${METADATA_FILE}" >> ${ROBOTOLOGY_INITIALIZATION_FILE}
-
 # This should theoretically help reducing the size of the final image
 FROM scratch
 
+# Setup entrypoint
+ARG ROBOTOLOGY_INITIALIZATION_FILE
+ARG METADATA_FILE
+ARG release
+ARG sbtag
 ARG metadata
 
 COPY --from=secondstage / /
@@ -112,7 +108,8 @@ EXPOSE 10000/tcp 10000/udp
 ENV QT_X11_NO_MITSHM=1
 ENV YARP_COLORED_OUTPUT=1
 
-ENV img_metadata=${metadata}
+RUN echo 'echo 'This images has release=$release and is built with superbuild_tag=$sbtag. Metadata=$metadata' '  >> ${METADATA_FILE} &&\
+    echo "source ${METADATA_FILE}" >> ${ROBOTOLOGY_INITIALIZATION_FILE}
 
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
 


### PR DESCRIPTION
Update children images:
- Update superbuild-ros2 image since now yarp-devices-ros2 is integrated in the robotology-superbuild
- Update superbuild-test image
- Add workaround to superbuild-icubhead-robometry image to make it recompiling starting from superbuild-icubhead
- Adjust step in superbuild base image