### PR TITLE
Fix data_hour_tag and childre image icub-main compilation

### DIFF
--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -335,9 +335,9 @@ jobs:
         - name: set date argument for Docker build
           id: get_date
           run: |
-            echo "$(date +'%d/%m/%Y')" > DATE_
-            echo "metadata=$(cat DATE_)" > DATE_TAG
-            echo $(cat DATE_TAG) >> $GITHUB_OUTPUT
+            echo "$(date +'%d/%m/%Y_%H:%M:%S')" > DATE_HOUR
+            echo "metadata=$(cat DATE_HOUR)" > DATE_HOUR_TAG
+            echo $(cat DATE_HOUR_TAG) >> $GITHUB_OUTPUT
           
  ##################### Here we check the release version and replace Custom with stable only for the image name ######################
         - name: Get release / master version

--- a/dockerfile_images/basic/superbuild-icubhead/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-icubhead/conf_build.ini
@@ -1,6 +1,6 @@
 [sources]
 START_IMG=ubuntu:jammy
-metadata={{steps.get_date.outputs.DATE_HOUR}}
+metadata={{steps.get_date.outputs.DATE_HOUR_TAG}}
 release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 

--- a/dockerfile_images/basic/superbuild-ros2/Dockerfile
+++ b/dockerfile_images/basic/superbuild-ros2/Dockerfile
@@ -102,7 +102,10 @@ RUN cd ${PROJECTS_DIR}/robotology-superbuild/build &&\
         -DCMAKE_INSTALL_PREFIX='/usr/local' \
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
         -DROBOTOLOGY_PROJECT_TAGS=${sbtag} \
+        # Disable icub-head to avoid conflict with auto-generated files
+        -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=OFF \ 
         -DNON_INTERACTIVE_BUILD:BOOL=ON \
+        # Enable ROS2 support
         -DROBOTOLOGY_USES_ROS2:BOOL=ON \
         -DYCM_EP_DEVEL_MODE_yarp-devices-ros2:BOOL=OFF && \
     cmake --build . -- ${CMAKE_EXTRA_OPTIONS}"

--- a/dockerfile_images/basic/superbuild-ros2/conf_build.ini
+++ b/dockerfile_images/basic/superbuild-ros2/conf_build.ini
@@ -1,6 +1,6 @@
 [sources]
 START_IMG={{env.REGISTRY}}/{{env.REPOSITORY_NAME}}/{{env.IMAGE_PREFIX}}superbuild-icubhead:{{steps.get_version.outputs.VERSION}}{{steps.get_version.outputs.TAG}}_sources
-metadata={{steps.get_date.outputs.DATE_HOUR}}
+metadata={{steps.get_date.outputs.DATE_HOUR_TAG}}
 release={{steps.get_version.outputs.VERSION}}
 sbtag={{matrix.tag}}
 


### PR DESCRIPTION
This PR fixes the compilation of children image.
We got an error when the children images re-build icub-main from the robotology. This error is due to the fact that auto-generated files from the ParamParser remain as uncommited changes in the src folder and this might let the build fail.
Moreover we have fixed the DATE_HOUT_TAG in the build.ini file since we were taking the wrong env variable. Doing so the metadata were not correctly displayed at the docker container startup